### PR TITLE
ADC input 0 is read into a "TAPE" register 

### DIFF
--- a/ZX-Spectrum.qsf
+++ b/ZX-Spectrum.qsf
@@ -29,7 +29,7 @@ set_global_assignment -name FAMILY "Cyclone V"
 set_global_assignment -name DEVICE 5CSEBA6U23I7
 set_global_assignment -name TOP_LEVEL_ENTITY sys_top
 set_global_assignment -name ORIGINAL_QUARTUS_VERSION 16.1.2
-set_global_assignment -name LAST_QUARTUS_VERSION "17.0.2 Standard Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "16.1.2 Standard Edition"
 set_global_assignment -name PROJECT_CREATION_TIME_DATE "01:53:30  APRIL 20, 2017"
 set_global_assignment -name DEVICE_FILTER_PACKAGE UFBGA
 set_global_assignment -name DEVICE_FILTER_PIN_COUNT 672
@@ -361,6 +361,8 @@ set_location_assignment PIN_W20 -to SW[3]
 
 set_global_assignment -name PRE_FLOW_SCRIPT_FILE "quartus_sh:sys/build_id.tcl"
 
+set_global_assignment -name ADV_NETLIST_OPT_SYNTH_WYSIWYG_REMAP ON
+set_global_assignment -name VERILOG_FILE jtframe_2308.v
 set_global_assignment -name CDF_FILE jtag.cdf
 set_global_assignment -name QIP_FILE sys/sys.qip
 set_global_assignment -name QIP_FILE t80/T80.qip
@@ -382,5 +384,4 @@ set_global_assignment -name SYSTEMVERILOG_FILE tape.sv
 set_global_assignment -name VERILOG_FILE mouse.v
 set_global_assignment -name SYSTEMVERILOG_FILE keyboard.sv
 set_global_assignment -name SYSTEMVERILOG_FILE "ZX-Spectrum.sv"
-set_global_assignment -name ADV_NETLIST_OPT_SYNTH_WYSIWYG_REMAP ON
 set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/ZX-Spectrum.qsf
+++ b/ZX-Spectrum.qsf
@@ -29,7 +29,7 @@ set_global_assignment -name FAMILY "Cyclone V"
 set_global_assignment -name DEVICE 5CSEBA6U23I7
 set_global_assignment -name TOP_LEVEL_ENTITY sys_top
 set_global_assignment -name ORIGINAL_QUARTUS_VERSION 16.1.2
-set_global_assignment -name LAST_QUARTUS_VERSION "16.1.2 Standard Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "17.1.0 Lite Edition"
 set_global_assignment -name PROJECT_CREATION_TIME_DATE "01:53:30  APRIL 20, 2017"
 set_global_assignment -name DEVICE_FILTER_PACKAGE UFBGA
 set_global_assignment -name DEVICE_FILTER_PIN_COUNT 672
@@ -68,14 +68,6 @@ set_global_assignment -name SEED 3
 #============================================================
 # ADC
 #============================================================
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ADC_CONVST
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ADC_SCK
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ADC_SDI
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ADC_SDO
-set_location_assignment PIN_U9 -to ADC_CONVST
-set_location_assignment PIN_V10 -to ADC_SCK
-set_location_assignment PIN_AC4 -to ADC_SDI
-set_location_assignment PIN_AD4 -to ADC_SDO
 
 #============================================================
 # ARDUINO
@@ -163,6 +155,19 @@ set_location_assignment PIN_AE25 -to AUDIO_R
 set_location_assignment PIN_AG26 -to AUDIO_SPDIF
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to AUDIO_*
 set_instance_assignment -name CURRENT_STRENGTH_NEW 8MA -to AUDIO_*
+
+#============================================================
+# ADC
+#============================================================
+set_location_assignment PIN_U9 -to ADC_CONVST
+set_location_assignment PIN_V10 -to ADC_SCK
+set_location_assignment PIN_AC4 -to ADC_SDI
+set_location_assignment PIN_AD4 -to ADC_SDO
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ADC_CONVST
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ADC_SCK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ADC_SDI
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to ADC_SDO
+
 
 #============================================================
 # SDRAM

--- a/ZX-Spectrum.sv
+++ b/ZX-Spectrum.sv
@@ -1056,7 +1056,7 @@ always @(posedge clk_sys) begin
 	end
 end
 
-assign tape_in = tape_loaded_reg ? tape_vin : ~(ear_out | mic_out);
+assign tape_in = tape_loaded_reg ? tape_vin ^ TAPE_IN : ~(ear_out | mic_out);
 
 //////////////////  ARCH SET  //////////////////
 

--- a/jtframe_2308.v
+++ b/jtframe_2308.v
@@ -1,0 +1,110 @@
+/*  This file is part of JTFRAME.
+    JTFRAME program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    JTFRAME program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with JTFRAME.  If not, see <http://www.gnu.org/licenses/>.
+
+    Author: Jose Tejada Gomez. Twitter: @topapate
+    Version: 1.0
+    Date: 2-4-2019 */
+
+// Driver for LTC2308 ADC
+
+module jtframe_2308(
+    input             rst_n,
+    input             clk,
+    input             cen,        // CEN+CLK < 40MHz
+    // ADC control
+    input             adc_sdo,
+    output reg        adc_convst,
+    output reg        adc_sck,
+    output            adc_sdi,
+    // ADC read data
+    output reg [11:0] adc_read
+);
+
+parameter ADC_PIN = 2'b00;
+parameter DIV_MAX  = 8'd100;  // frequency divider to get sampling rate
+
+wire [1:0] adc_pin = ADC_PIN;
+wire [7:0] div_max = DIV_MAX;
+
+wire [5:0] cfg = { 
+    1'b1,   // single ended
+    1'b0,   // odd
+    adc_pin,
+    1'b1,   // unipolar
+    1'b0    // sleep
+};
+
+// Input frequency divider
+reg [7:0] div;
+
+always @(posedge clk or negedge rst_n)
+    if(!rst_n) begin
+        div <= 8'd0;
+    end else if(cen) begin
+        div <= div == div_max ? 8'd0 : div+8'd1;
+    end
+
+// state machine
+// 0 = send CFG
+// 1 = read value
+reg state;
+reg set_cfg;
+
+always @(posedge clk or negedge rst_n)
+    if(!rst_n) begin
+        state <= 1'b0;
+    end else if(cen) begin
+        set_cfg  <= 1'b0;
+        adc_convst <= 1'b0;
+
+        if( div==8'd0 ) begin
+            state <= ~state;
+            if( state==1'b0 )
+                set_cfg <= 1'b1;
+            else
+                adc_convst <= 1'b1;
+        end        
+    end
+
+// Send data
+reg  [11:0] scnt, readbuf;
+reg  [ 5:0] cfg_sr;
+
+assign adc_sdi = cfg_sr[5];
+
+always @(posedge clk or negedge rst_n)
+    if(!rst_n) begin
+        scnt    <= 'b0;
+        adc_sck <= 1'b0;
+    end else if(cen) begin
+        if( set_cfg ) begin
+            scnt  <= ~12'd0;
+            cfg_sr <= cfg;
+        end
+        if( scnt[0] ) begin
+            adc_sck <= ~adc_sck;
+            // if(toggle) scnt    <= { 1'b0, scnt[11:1] };
+            if(  adc_sck ) { cfg_sr } <= { cfg_sr[4:0], 1'b0 };
+            if( !adc_sck ) begin
+                readbuf <= { readbuf[10:0], adc_sdo };
+                scnt    <= { 1'b0, scnt[11:1] };
+            end
+        end
+        else begin
+            adc_read <= readbuf;
+            adc_sck  <= 1'b0;
+        end
+    end
+
+endmodule // jtframe_2308

--- a/jtframe_tape.v
+++ b/jtframe_tape.v
@@ -1,0 +1,73 @@
+/*  This file is part of JTFRAME.
+    JTFRAME program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    JTFRAME program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with JTFRAME.  If not, see <http://www.gnu.org/licenses/>.
+
+    Author: Jose Tejada Gomez. Twitter: @topapate
+    Version: 1.0
+    Date: 2-4-2019 */
+
+// Tape input for DE10-Nano board (MiSTer)
+
+module jtframe_tape(
+    input             clk,      // 50 MHz clock
+    // ADC control
+    input             adc_sdo,
+    output            adc_convst,
+    output            adc_sck,
+    output            adc_sdi,
+    // Tape data
+    output reg        tape
+);
+
+reg [5:0] rst_sr=6'b100_000;
+always @(negedge clk) begin
+    rst_sr <= { rst_sr[4:0], 1'b1 };
+end
+
+wire rst_n = rst_sr[5];
+
+reg last_convst;
+wire [11:0] adc_read;
+reg [11:0] avg_buf0;
+wire[12:0] sum = {1'b0,avg_buf0} + {1'b0,adc_read};
+wire [7:0] avg = sum[12:4];
+
+always @(posedge clk ) begin
+    last_convst <= adc_convst;
+    if( last_convst && !adc_convst ) begin
+        avg_buf0 <= adc_read;
+    end
+    tape  <= avg > 8'h80; // set a threshold different from 0 to avoid noise
+end
+
+// clock divider
+reg [1:0] adccen_cnt=0;
+reg adccen;
+always @(negedge clk) begin
+    adccen_cnt <= adccen_cnt+2'd1;
+    adccen <= adccen_cnt == 2'b00;
+end
+
+jtframe_2308 i_jtframe_2308 (
+    .rst_n     (rst_n     ),
+    .clk       (clk       ),
+    .cen       (adccen    ),
+    .adc_sdo   (adc_sdo   ),
+    .adc_convst(adc_convst),
+    .adc_sck   (adc_sck   ),
+    .adc_sdi   (adc_sdi   ),
+    .adc_read  (adc_read  )
+);
+
+
+endmodule // jtframe_tape

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -113,7 +113,7 @@ always @(posedge FPGA_CLK3_50 ) begin
         // noise
 end
 
-jtframe_2308 #(.DIV_MAX(8'd10)) tape_adc(
+jtframe_2308 #(.DIV_MAX(8'd50)) tape_adc(
     .rst_n      ( ~reset        ),
     .clk        ( FPGA_CLK3_50  ),
     .cen        ( ce_pix        ),  // clk & cen < 40 MHz

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -104,39 +104,17 @@ module sys_top
 
 
 assign SDIO_DAT[2:1] = 2'bZZ;
-reg tapein;
+wire tapein;
 
 /////////// Analog Tape Reading
-wire [11:0] adc_read;
-always @(posedge FPGA_CLK3_50 ) begin
-    tapein <= adc_read > 12'h40; // set a threshold different from 0 to avoid
-        // noise
-end
-
-reg [1:0] adccen_cnt=0;
-reg adccen;
-always @(negedge FPGA_CLK3_50) begin
-    adccen_cnt <= adccen_cnt+2'd1;
-    adccen <= adccen_cnt == 2'b00;
-end
-
-reg [5:0] adcrst_sr=6'b100_000;
-always @(negedge FPGA_CLK3_50) begin
-    adcrst_sr <= { adcrst_sr[4:0], 1'b1 };
-end
-
-jtframe_2308 tape_adc(
-    .rst_n      ( adcrst_sr[5]  ),
-    .clk        ( FPGA_CLK3_50  ),
-    .cen        ( adccen        ),  // clk & cen < 40 MHz
-    .adc_sdi    ( ADC_SDI       ),
-    .adc_convst ( ADC_CONVST    ),
-    .adc_sck    ( ADC_SCK       ),
-    .adc_sdo    ( ADC_SDO       ),
-    .adc_read   ( adc_read      )
+jtframe_tape u_tape (
+	.clk        ( FPGA_CLK3_50   ),
+	.adc_sdo    ( ADC_SDO        ),
+	.adc_convst ( ADC_CONVST     ),
+	.adc_sck    ( ADC_SCK        ),
+	.adc_sdi    ( ADC_SDI        ),
+	.tape       ( tapein         )
 );
-
-assign LED = adc_read[7:0];
 
 //////////////////////////  LEDs  ///////////////////////////////////////
 
@@ -153,7 +131,7 @@ assign LED_HDD   = led_d ? 1'bZ : 1'b0;
 assign LED_USER  = led_u ? 1'bZ : 1'b0;
 
 //LEDs on main board
-// assign LED = (led_overtake & led_state) | (~led_overtake & {1'b0,led_locked,1'b0, ~led_p, 1'b0, ~led_d, 1'b0, ~led_u});
+assign LED = (led_overtake & led_state) | (~led_overtake & {1'b0,led_locked,1'b0, ~led_p, 1'b0, ~led_d, 1'b0, ~led_u});
 
 
 //////////////////////////  Buttons  ///////////////////////////////////
@@ -869,7 +847,7 @@ wire        osd_status;
 
 wire  [5:0] user_out, user_in;
 assign led_user = tapein;
-/*
+
 emu emu
 (
 	.CLK_50M(FPGA_CLK3_50),
@@ -943,7 +921,6 @@ emu emu
 
 	.OSD_STATUS(osd_status)
 );
-*/
 
 endmodule
 /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
ADC is driven to read its input. An average of two measurements is taken as the analog TAPE input to the core. The combination of this signal with the former tape signal may not be correct and needs review.