### PR TITLE
Update keyboard.sv

### DIFF
--- a/ZX-Spectrum.sv
+++ b/ZX-Spectrum.sv
@@ -178,6 +178,7 @@ localparam CONF_STR = {
 
 	"-;",
 	"OHJ,Joystick,Kempston,Sinclair I,Sinclair II,Sinclair I+II,Cursor;",
+	"OQ,Recreated Keyboard,Disabled,Enabled;",
 	"-;",
 	"O6,Fast Tape Load,On,Off;",
 	"OMO,CPU Speed,Original,7MHz,14MHz,28MHz,56MHz;",
@@ -907,6 +908,7 @@ end
 wire [11:1] Fn;
 wire  [2:0] mod;
 wire  [4:0] key_data;
+wire        recreated_keyboard = status[26];
 keyboard kbd( .* );
 
 reg         mouse_sel;

--- a/ZX-Spectrum.sv
+++ b/ZX-Spectrum.sv
@@ -178,7 +178,6 @@ localparam CONF_STR = {
 
 	"-;",
 	"OHJ,Joystick,Kempston,Sinclair I,Sinclair II,Sinclair I+II,Cursor;",
-	"OQ,Recreated Keyboard,Disabled,Enabled;",
 	"-;",
 	"O6,Fast Tape Load,On,Off;",
 	"OMO,CPU Speed,Original,7MHz,14MHz,28MHz,56MHz;",
@@ -908,7 +907,6 @@ end
 wire [11:1] Fn;
 wire  [2:0] mod;
 wire  [4:0] key_data;
-wire        recreated_keyboard = status[26];
 keyboard kbd( .* );
 
 reg         mouse_sel;

--- a/rtl/keyboard.sv
+++ b/rtl/keyboard.sv
@@ -36,21 +36,12 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-// Recreated spectrum keyboard - Layer A / game mode:
-// https://web.archive.org/web/20201012150702/http://sinclair.recreatedzxspectrum.com/downloads/recreated_sinclair_zx_spectrum_developer_guide_placeholder_ZX%20Keyboard%20Technical%20Document_a15_v1_1a.pdf
-// In game mode there is a separate ps2 key code for each button down and each button up. 
-// eg. 'q' button down sends 'u' down/up codes, 'q' button released sends 'v' down/up codes.
-// The keycodes used here are those observed in the mister main menu debug output. 
-// They don't match any of the columns in the document exactly.
-//
-
 // PS/2 scancode to Spectrum matrix conversion
 module keyboard
 (
 	input             reset,
 	input             clk_sys,
-	input			  recreated_keyboard,
-	
+
 	input      [10:0] ps2_key,
 
 	input      [15:0] addr,
@@ -63,7 +54,7 @@ module keyboard
 reg  [4:0] keys[7:0];
 reg        release_btn = 0;
 reg  [7:0] code;
-reg        lshift = 0;
+reg        extended = 0;
 
 // Output addressed row to ULA
 assign key_data = (!addr[8]  ? keys[0] : 5'b11111)
@@ -76,7 +67,11 @@ assign key_data = (!addr[8]  ? keys[0] : 5'b11111)
                  &(!addr[15] ? keys[7] : 5'b11111);
 
 reg  input_strobe = 0;
-wire shift = mod[0];
+
+reg  left_shift = 0;
+wire shift = mod[0] | left_shift;
+reg  right_ctrl = 0;
+wire ctrl = mod[2] | right_ctrl;
 
 always @(posedge clk_sys) begin
 	reg old_reset = 0;
@@ -91,14 +86,22 @@ always @(posedge clk_sys) begin
 		keys[5] <= 5'b11111;
 		keys[6] <= 5'b11111;
 		keys[7] <= 5'b11111;
+		left_shift <= 0;
+		right_ctrl <= 0;
 	end
 
 	if(input_strobe) begin
 		case(code)
 			8'h59: mod[0]<= ~release_btn; // right shift
-			8'h12: lshift<= ~release_btn; // left shift
+			8'h12: left_shift <= ~release_btn;
 			8'h11: mod[1]<= ~release_btn; // alt
-			8'h14: mod[2]<= ~release_btn; // ctrl
+			8'h14: begin
+					if (~extended) begin
+						mod[2]<= ~release_btn; // left_ctrl
+					end else begin
+						right_ctrl <= ~release_btn;
+					end
+				end
 			8'h05: Fn[1] <= ~release_btn; // F1
 			8'h06: Fn[2] <= ~release_btn; // F2
 			8'h04: Fn[3] <= ~release_btn; // F3
@@ -111,250 +114,155 @@ always @(posedge clk_sys) begin
 			8'h09: Fn[10]<= ~release_btn; // F10
 			8'h78: Fn[11]<= ~release_btn; // F11
 		endcase
-
-		if(!recreated_keyboard) begin
+		
+		// update CAPS SHIFT and SYMBOL SHIFT
+		if (~release_btn) begin // key down
 			case(code)
-				8'h12 : keys[0][0] <= release_btn; // Left shift (CAPS SHIFT)
-				8'h59 : keys[0][0] <= release_btn; // Right shift (CAPS SHIFT)
-				8'h1a : keys[0][1] <= release_btn; // Z
-				8'h22 : keys[0][2] <= release_btn; // X
-				8'h21 : keys[0][3] <= release_btn; // C
-				8'h2a : keys[0][4] <= release_btn; // V
+				// special keys sent to the ULA as key combinations
 
-				8'h1c : keys[1][0] <= release_btn; // A
-				8'h1b : keys[1][1] <= release_btn; // S
-				8'h23 : keys[1][2] <= release_btn; // D
-				8'h2b : keys[1][3] <= release_btn; // F
-				8'h34 : keys[1][4] <= release_btn; // G
-
-				8'h15 : keys[2][0] <= release_btn; // Q
-				8'h1d : keys[2][1] <= release_btn; // W
-				8'h24 : keys[2][2] <= release_btn; // E
-				8'h2d : keys[2][3] <= release_btn; // R
-				8'h2c : keys[2][4] <= release_btn; // T
-
-				8'h16 : keys[3][0] <= release_btn; // 1
-				8'h1e : keys[3][1] <= release_btn; // 2
-				8'h26 : keys[3][2] <= release_btn; // 3
-				8'h25 : keys[3][3] <= release_btn; // 4
-				8'h2e : keys[3][4] <= release_btn; // 5
-
-				8'h45 : keys[4][0] <= release_btn; // 0
-				8'h46 : keys[4][1] <= release_btn; // 9
-				8'h3e : keys[4][2] <= release_btn; // 8
-				8'h3d : keys[4][3] <= release_btn; // 7
-				8'h36 : keys[4][4] <= release_btn; // 6
-
-				8'h4d : keys[5][0] <= release_btn; // P
-				8'h44 : keys[5][1] <= release_btn; // O
-				8'h43 : keys[5][2] <= release_btn; // I
-				8'h3c : keys[5][3] <= release_btn; // U
-				8'h35 : keys[5][4] <= release_btn; // Y
-
-				8'h5a : keys[6][0] <= release_btn; // ENTER
-				8'h4b : keys[6][1] <= release_btn; // L
-				8'h42 : keys[6][2] <= release_btn; // K
-				8'h3b : keys[6][3] <= release_btn; // J
-				8'h33 : keys[6][4] <= release_btn; // H
-
-				8'h29 : keys[7][0] <= release_btn; // SPACE
-				8'h14 : keys[7][1] <= release_btn; // CTRL (Symbol Shift)
-				8'h3a : keys[7][2] <= release_btn; // M
-				8'h31 : keys[7][3] <= release_btn; // N
-				8'h32 : keys[7][4] <= release_btn; // B
-
-				// Cursor keys - these are actually extended (E0 xx), but
-				// the scancodes for the numeric keypad cursor keys are
-				// are the same but without the extension, so we'll accept
-				// the codes whether they are extended or not
-				8'h6B : begin // Left (CAPS 5)
-						keys[0][0] <= release_btn;
-						keys[3][4] <= release_btn;
-					end
-				8'h72 : begin // Down (CAPS 6)
-						keys[0][0] <= release_btn;
-						keys[4][4] <= release_btn;
-					end
-				8'h75 : begin // Up (CAPS 7)
-						keys[0][0] <= release_btn;
-						keys[4][3] <= release_btn;
-					end
-				8'h74 : begin // Right (CAPS 8)
-						keys[0][0] <= release_btn;
-						keys[4][2] <= release_btn;
-					end
-
-				// Other special keys sent to the ULA as key combinations
-				8'h66 : begin // Backspace (CAPS 0)
-						keys[0][0] <= release_btn;
-						keys[4][0] <= release_btn;
-					end
-				8'h58 : begin // Caps lock (CAPS 2)
-						keys[0][0] <= release_btn;
-						keys[3][1] <= release_btn;
-					end
+				// keys that add CAPS SHIFT, and remove SYMBOL SHIFT
+				8'h6B, // Left (CAPS 5)
+				8'h72, // Down (CAPS 6)
+				8'h75, // Up (CAPS 7)
+				8'h74, // Right (CAPS 8)
+				8'h66, // Backspace (CAPS 0)
+				8'h58, // Caps lock (CAPS 2)
 				8'h76 : begin // Escape (CAPS SPACE)
-						keys[0][0] <= release_btn;
-						keys[7][0] <= release_btn;
+						keys[0][0] <= 0; // CAPS SHIFT on
+						keys[7][1] <= 1; // SYMBOL SHIFT off
 					end
-				8'h49 : begin // . <
-						keys[7][1] <= release_btn;
-						keys[2][4] <= release_btn | ~shift;
-						keys[7][2] <= release_btn |  shift;
+
+				// keys that add SYMBOL SHIFT and remove CAPS SHIFT
+				// , < . > / ? ; : ' " [ { ] } - _ = + ` ~ *
+				8'h49, 8'h41, 8'h4A, 8'h4C, 8'h52, 8'h54, 8'h5b, 8'h4E, 8'h55, 8'h0E, 8'h7C, 8'h5D : begin 
+						keys[7][1] <= 0; // SYMBOL SHIFT on
+						keys[0][0] <= 1; // CAPS SHIFT off
 					end
-				8'h41 : begin // , >
-						keys[7][1] <= release_btn;
-						keys[2][3] <= release_btn | ~shift;
-						keys[7][3] <= release_btn |  shift;
+
+				default: begin
+						keys[0][0] <= ~shift; // CAPS SHIFT
+						keys[7][1] <= ~ctrl;  // SYMBOL SHIFT
 					end
-				8'h4A : begin // / ?
-						keys[7][1] <= release_btn;
-						keys[0][3] <= release_btn | ~shift;
-						keys[0][4] <= release_btn |  shift;
+			endcase
+		end else begin // (release_btn) - key up
+			case(code)
+				// only sets CAPS SHIFT and SYMBOL SHIFT on shift or ctrl release
+				// fixes fast alternating between left cursor and right cursor giving 5s and 8s
+				8'h12: begin // left shift
+						keys[0][0] <= ~mod[0]; // CAPS SHIFT
 					end
-				8'h4C : begin // ; :
-						keys[7][1] <= release_btn;
-						keys[0][1] <= release_btn | ~shift;
-						keys[5][1] <= release_btn |  shift;
+				8'h59: begin // right shift
+						keys[0][0] <= ~left_shift; // CAPS SHIFT
 					end
-				8'h52 : begin // " '
-						keys[7][1] <= release_btn;
-						keys[4][3] <= release_btn | ~shift;
-						keys[5][0] <= release_btn |  shift;
-					end
-				8'h54 : begin // (
-						keys[7][1] <= release_btn;
-						keys[4][2] <= release_btn;
-					end
-				8'h5B : begin // )
-						keys[7][1] <= release_btn;
-						keys[4][1] <= release_btn;
-					end
-				8'h4E : begin // - _
-						keys[7][1] <= release_btn;
-						keys[4][0] <= release_btn | ~shift;
-						keys[6][3] <= release_btn |  shift;
-					end
-				8'h55 : begin // = +
-						keys[7][1] <= release_btn;
-						keys[6][2] <= release_btn | ~shift;
-						keys[6][1] <= release_btn |  shift;
-					end
-				8'h0E : begin // '
-						keys[7][1] <= release_btn;
-						keys[4][3] <= release_btn;
-					end
-				8'h5D : begin // *
-						keys[7][1] <= release_btn;
-						keys[7][4] <= release_btn;
+				8'h14: begin
+						if (~extended) begin // left ctrl
+							keys[7][1] <= ~right_ctrl; // SYMBOL SHIFT
+						end else begin // right ctrl
+							keys[7][1] <= ~mod[2]; // SYMBOL SHIFT
+						end
 					end
 				default: ;
 			endcase
-		end else begin // recreated keyboard
-			if(!release_btn) begin // only consider key code down edges; there is a different key code for each button down and each button up
-				if(!lshift) begin
-					case(code)
-						8'h3e : keys[0][0] <= 0; // CAPS SHIFT
-						8'h46 : keys[0][0] <= 1;
-						8'h4e : keys[0][2] <= 0; // X
-						8'h55 : keys[0][2] <= 1;
-						8'h54 : keys[0][3] <= 0; // C
-						8'h5b : keys[0][3] <= 1;
-						8'h4c : keys[0][4] <= 0; // V
-
-						8'h3c : keys[2][0] <= 0; // Q
-						8'h2a : keys[2][0] <= 1;
-						8'h1d : keys[2][1] <= 0; // W
-						8'h22 : keys[2][1] <= 1;
-						8'h35 : keys[2][2] <= 0; // E
-						8'h1a : keys[2][2] <= 1;
-
-						8'h1C : keys[3][0] <= 0; // 1
-						8'h32 : keys[3][0] <= 1;
-						8'h21 : keys[3][1] <= 0; // 2
-						8'h23 : keys[3][1] <= 1;
-						8'h24 : keys[3][2] <= 0; // 3
-						8'h2b : keys[3][2] <= 1;
-						8'h34 : keys[3][3] <= 0; // 4
-						8'h33 : keys[3][3] <= 1;
-						8'h43 : keys[3][4] <= 0; // 5
-						8'h3b : keys[3][4] <= 1;
-
-						8'h1b : keys[4][0] <= 0; // 0
-						8'h2c : keys[4][0] <= 1;
-						8'h15 : keys[4][1] <= 0; // 9
-						8'h2d : keys[4][1] <= 1;
-						8'h44 : keys[4][2] <= 0; // 8
-						8'h4d : keys[4][2] <= 1;
-						8'h3a : keys[4][3] <= 0; // 7
-						8'h31 : keys[4][3] <= 1;
-						8'h42 : keys[4][4] <= 0; // 6
-						8'h4b : keys[4][4] <= 1;
-
-						8'h36 : keys[6][0] <= 0; // ENTER
-						8'h3d : keys[6][0] <= 1;
-						8'h25 : keys[6][1] <= 0; // L
-						8'h2e : keys[6][1] <= 1;
-						8'h1e : keys[6][2] <= 0; // K
-						8'h26 : keys[6][2] <= 1;
-						8'h45 : keys[6][3] <= 0; // J
-						8'h16 : keys[6][3] <= 1;
-
-						8'h4a : keys[7][3] <= 0; // N
-						8'h41 : keys[7][4] <= 0; // B
-						8'h49 : keys[7][4] <= 1;
-
-						default: ;
-					endcase
-				end else begin // left shift
-					case(code)
-						8'h41 : keys[0][1] <= 0; // Z
-						8'h49 : keys[0][1] <= 1;
-						8'h4c : keys[0][4] <= 1; // V
-
-						8'h44 : keys[1][0] <= 0; // A
-						8'h4d : keys[1][0] <= 1;
-						8'h15 : keys[1][1] <= 0; // S
-						8'h2d : keys[1][1] <= 1;
-						8'h1b : keys[1][2] <= 0; // D
-						8'h2c : keys[1][2] <= 1;
-						8'h3c : keys[1][3] <= 0; // F
-						8'h2a : keys[1][3] <= 1;
-						8'h1d : keys[1][4] <= 0; // G
-						8'h22 : keys[1][4] <= 1;
-
-						8'h1c : keys[2][3] <= 0; // R
-						8'h32 : keys[2][3] <= 1;
-						8'h21 : keys[2][4] <= 0; // T
-						8'h23 : keys[2][4] <= 1;
-
-						8'h3a : keys[5][0] <= 0; // P
-						8'h31 : keys[5][0] <= 1;
-						8'h42 : keys[5][1] <= 0; // O
-						8'h4b : keys[5][1] <= 1;
-						8'h43 : keys[5][2] <= 0; // I
-						8'h3b : keys[5][2] <= 1;
-						8'h34 : keys[5][3] <= 0; // U
-						8'h33 : keys[5][3] <= 1;
-						8'h24 : keys[5][4] <= 0; // Y
-						8'h2b : keys[5][4] <= 1;
-
-						8'h35 : keys[6][4] <= 0; // H
-						8'h1a : keys[6][4] <= 1;
-
-						8'h2e : keys[7][0] <= 0; // SPACE
-						8'h36 : keys[7][0] <= 1;
-						8'h16 : keys[7][1] <= 0; // SYMBOL SHIFT
-						8'h25 : keys[7][1] <= 1;
-						8'h54 : keys[7][2] <= 0; // M
-						8'h5b : keys[7][2] <= 1;
-						8'h4a : keys[7][3] <= 1; // N
-
-						default: ;
-					endcase
-				end
-			end
 		end
+
+		case(code)
+			// keys[0][0] CAPS SHIFT is set above
+			8'h1a : keys[0][1] <= release_btn; // Z
+			8'h22 : keys[0][2] <= release_btn; // X
+			8'h21 : keys[0][3] <= release_btn; // C
+			8'h2a : keys[0][4] <= release_btn; // V
+
+			8'h1c : keys[1][0] <= release_btn; // A
+			8'h1b : keys[1][1] <= release_btn; // S
+			8'h23 : keys[1][2] <= release_btn; // D
+			8'h2b : keys[1][3] <= release_btn; // F
+			8'h34 : keys[1][4] <= release_btn; // G
+
+			8'h15 : keys[2][0] <= release_btn; // Q
+			8'h1d : keys[2][1] <= release_btn; // W
+			8'h24 : keys[2][2] <= release_btn; // E
+			8'h2d : keys[2][3] <= release_btn; // R
+			8'h2c : keys[2][4] <= release_btn; // T
+
+			8'h16 : keys[3][0] <= release_btn; // 1
+			8'h1e : keys[3][1] <= release_btn; // 2
+			8'h26 : keys[3][2] <= release_btn; // 3
+			8'h25 : keys[3][3] <= release_btn; // 4
+			8'h2e : keys[3][4] <= release_btn; // 5
+
+			8'h45 : keys[4][0] <= release_btn; // 0
+			8'h46 : keys[4][1] <= release_btn; // 9
+			8'h3e : keys[4][2] <= release_btn; // 8
+			8'h3d : keys[4][3] <= release_btn; // 7
+			8'h36 : keys[4][4] <= release_btn; // 6
+
+			8'h4d : keys[5][0] <= release_btn; // P
+			8'h44 : keys[5][1] <= release_btn; // O
+			8'h43 : keys[5][2] <= release_btn; // I
+			8'h3c : keys[5][3] <= release_btn; // U
+			8'h35 : keys[5][4] <= release_btn; // Y
+
+			8'h5a : keys[6][0] <= release_btn; // ENTER
+			8'h4b : keys[6][1] <= release_btn; // L
+			8'h42 : keys[6][2] <= release_btn; // K
+			8'h3b : keys[6][3] <= release_btn; // J
+			8'h33 : keys[6][4] <= release_btn; // H
+
+			8'h29 : keys[7][0] <= release_btn; // SPACE
+			// keys[7][1] SYMBOL SHIFT is set above
+			8'h3a : keys[7][2] <= release_btn; // M
+			8'h31 : keys[7][3] <= release_btn; // N
+			8'h32 : keys[7][4] <= release_btn; // B
+
+			// Cursor keys - these are actually extended (E0 xx), but
+			// the scancodes for the numeric keypad cursor keys are
+			// are the same but without the extension, so we'll accept
+			// the codes whether they are extended or not
+			8'h6B : keys[3][4] <= release_btn; // Left (CAPS 5)
+			8'h72 : keys[4][4] <= release_btn; // Down (CAPS 6)
+			8'h75 : keys[4][3] <= release_btn; // Up (CAPS 7)
+			8'h74 : keys[4][2] <= release_btn; // Right (CAPS 8)
+
+			// Other special keys sent to the ULA as key combinations
+			8'h66 : keys[4][0] <= release_btn; // Backspace (CAPS 0)
+			8'h58 : keys[3][1] <= release_btn; // Caps lock (CAPS 2)
+			8'h76 : keys[7][0] <= release_btn; // Escape (CAPS SPACE)
+
+			8'h49 : begin // , <
+					keys[2][4] <= release_btn | ~shift; // <
+					keys[7][3] <= release_btn |  shift; // ,
+				end
+			8'h41 : begin // . >
+					keys[2][3] <= release_btn | ~shift; // >
+					keys[7][2] <= release_btn |  shift; // .
+				end
+			8'h4A : begin // / ?
+					keys[0][3] <= release_btn | ~shift; // ?
+					keys[0][4] <= release_btn |  shift; // /
+				end
+			8'h4C : begin // ; :
+					keys[0][1] <= release_btn | ~shift; // :
+					keys[5][1] <= release_btn |  shift; // ;
+				end
+			8'h52 : begin // ' "	// note:  ' and " intentionally swapped
+					keys[5][0] <= release_btn |  shift; // "
+					keys[4][3] <= release_btn | ~shift; // '
+				end
+			8'h54 : keys[4][3] <= release_btn; // [ { give (
+			8'h5B : keys[4][3] <= release_btn; // ] } give )
+			8'h4E : begin // - _
+					keys[4][0] <= release_btn | ~shift; // _
+					keys[6][3] <= release_btn |  shift; // -
+				end
+			8'h55 : begin // = +
+					keys[6][2] <= release_btn | ~shift; // +
+					keys[6][1] <= release_btn |  shift; // =
+				end
+			8'h0E : keys[4][3] <= release_btn; // ` ~ give `
+			8'h7C : keys[7][4] <= release_btn; // numeric *
+			8'h5D : keys[7][4] <= release_btn; // \ | give *
+			default: ;
+		endcase
 	end
 end
 
@@ -399,6 +307,7 @@ always @(posedge clk_sys) begin
 			if(old_state != ps2_key[10]) begin
 				release_btn <= ~ps2_key[9];
 				code <= ps2_key[7:0];
+				extended <= ps2_key[8];
 				input_strobe <= 1;
 				if((ps2_key[8:0] == 9) && ~ps2_key[9]) auto_pos <= 1; // F10
 			end

--- a/rtl/keyboard.sv
+++ b/rtl/keyboard.sv
@@ -36,12 +36,21 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
+// Recreated spectrum keyboard - Layer A / game mode:
+// https://web.archive.org/web/20201012150702/http://sinclair.recreatedzxspectrum.com/downloads/recreated_sinclair_zx_spectrum_developer_guide_placeholder_ZX%20Keyboard%20Technical%20Document_a15_v1_1a.pdf
+// In game mode there is a separate ps2 key code for each button down and each button up. 
+// eg. 'q' button down sends 'u' down/up codes, 'q' button released sends 'v' down/up codes.
+// The keycodes used here are those observed in the mister main menu debug output. 
+// They don't match any of the columns in the document exactly.
+//
+
 // PS/2 scancode to Spectrum matrix conversion
 module keyboard
 (
 	input             reset,
 	input             clk_sys,
-
+	input			  recreated_keyboard,
+	
 	input      [10:0] ps2_key,
 
 	input      [15:0] addr,
@@ -54,7 +63,7 @@ module keyboard
 reg  [4:0] keys[7:0];
 reg        release_btn = 0;
 reg  [7:0] code;
-reg        extended = 0;
+reg        lshift = 0;
 
 // Output addressed row to ULA
 assign key_data = (!addr[8]  ? keys[0] : 5'b11111)
@@ -67,11 +76,7 @@ assign key_data = (!addr[8]  ? keys[0] : 5'b11111)
                  &(!addr[15] ? keys[7] : 5'b11111);
 
 reg  input_strobe = 0;
-
-reg  left_shift = 0;
-wire shift = mod[0] | left_shift;
-reg  right_ctrl = 0;
-wire ctrl = mod[2] | right_ctrl;
+wire shift = mod[0];
 
 always @(posedge clk_sys) begin
 	reg old_reset = 0;
@@ -86,22 +91,14 @@ always @(posedge clk_sys) begin
 		keys[5] <= 5'b11111;
 		keys[6] <= 5'b11111;
 		keys[7] <= 5'b11111;
-		left_shift <= 0;
-		right_ctrl <= 0;
 	end
 
 	if(input_strobe) begin
 		case(code)
 			8'h59: mod[0]<= ~release_btn; // right shift
-			8'h12: left_shift <= ~release_btn;
+			8'h12: lshift<= ~release_btn; // left shift
 			8'h11: mod[1]<= ~release_btn; // alt
-			8'h14: begin
-					if (~extended) begin
-						mod[2]<= ~release_btn; // left_ctrl
-					end else begin
-						right_ctrl <= ~release_btn;
-					end
-				end
+			8'h14: mod[2]<= ~release_btn; // ctrl
 			8'h05: Fn[1] <= ~release_btn; // F1
 			8'h06: Fn[2] <= ~release_btn; // F2
 			8'h04: Fn[3] <= ~release_btn; // F3
@@ -114,155 +111,250 @@ always @(posedge clk_sys) begin
 			8'h09: Fn[10]<= ~release_btn; // F10
 			8'h78: Fn[11]<= ~release_btn; // F11
 		endcase
-		
-		// update CAPS SHIFT and SYMBOL SHIFT
-		if (~release_btn) begin // key down
-			case(code)
-				// special keys sent to the ULA as key combinations
 
-				// keys that add CAPS SHIFT, and remove SYMBOL SHIFT
-				8'h6B, // Left (CAPS 5)
-				8'h72, // Down (CAPS 6)
-				8'h75, // Up (CAPS 7)
-				8'h74, // Right (CAPS 8)
-				8'h66, // Backspace (CAPS 0)
-				8'h58, // Caps lock (CAPS 2)
+		if(!recreated_keyboard) begin
+			case(code)
+				8'h12 : keys[0][0] <= release_btn; // Left shift (CAPS SHIFT)
+				8'h59 : keys[0][0] <= release_btn; // Right shift (CAPS SHIFT)
+				8'h1a : keys[0][1] <= release_btn; // Z
+				8'h22 : keys[0][2] <= release_btn; // X
+				8'h21 : keys[0][3] <= release_btn; // C
+				8'h2a : keys[0][4] <= release_btn; // V
+
+				8'h1c : keys[1][0] <= release_btn; // A
+				8'h1b : keys[1][1] <= release_btn; // S
+				8'h23 : keys[1][2] <= release_btn; // D
+				8'h2b : keys[1][3] <= release_btn; // F
+				8'h34 : keys[1][4] <= release_btn; // G
+
+				8'h15 : keys[2][0] <= release_btn; // Q
+				8'h1d : keys[2][1] <= release_btn; // W
+				8'h24 : keys[2][2] <= release_btn; // E
+				8'h2d : keys[2][3] <= release_btn; // R
+				8'h2c : keys[2][4] <= release_btn; // T
+
+				8'h16 : keys[3][0] <= release_btn; // 1
+				8'h1e : keys[3][1] <= release_btn; // 2
+				8'h26 : keys[3][2] <= release_btn; // 3
+				8'h25 : keys[3][3] <= release_btn; // 4
+				8'h2e : keys[3][4] <= release_btn; // 5
+
+				8'h45 : keys[4][0] <= release_btn; // 0
+				8'h46 : keys[4][1] <= release_btn; // 9
+				8'h3e : keys[4][2] <= release_btn; // 8
+				8'h3d : keys[4][3] <= release_btn; // 7
+				8'h36 : keys[4][4] <= release_btn; // 6
+
+				8'h4d : keys[5][0] <= release_btn; // P
+				8'h44 : keys[5][1] <= release_btn; // O
+				8'h43 : keys[5][2] <= release_btn; // I
+				8'h3c : keys[5][3] <= release_btn; // U
+				8'h35 : keys[5][4] <= release_btn; // Y
+
+				8'h5a : keys[6][0] <= release_btn; // ENTER
+				8'h4b : keys[6][1] <= release_btn; // L
+				8'h42 : keys[6][2] <= release_btn; // K
+				8'h3b : keys[6][3] <= release_btn; // J
+				8'h33 : keys[6][4] <= release_btn; // H
+
+				8'h29 : keys[7][0] <= release_btn; // SPACE
+				8'h14 : keys[7][1] <= release_btn; // CTRL (Symbol Shift)
+				8'h3a : keys[7][2] <= release_btn; // M
+				8'h31 : keys[7][3] <= release_btn; // N
+				8'h32 : keys[7][4] <= release_btn; // B
+
+				// Cursor keys - these are actually extended (E0 xx), but
+				// the scancodes for the numeric keypad cursor keys are
+				// are the same but without the extension, so we'll accept
+				// the codes whether they are extended or not
+				8'h6B : begin // Left (CAPS 5)
+						keys[0][0] <= release_btn;
+						keys[3][4] <= release_btn;
+					end
+				8'h72 : begin // Down (CAPS 6)
+						keys[0][0] <= release_btn;
+						keys[4][4] <= release_btn;
+					end
+				8'h75 : begin // Up (CAPS 7)
+						keys[0][0] <= release_btn;
+						keys[4][3] <= release_btn;
+					end
+				8'h74 : begin // Right (CAPS 8)
+						keys[0][0] <= release_btn;
+						keys[4][2] <= release_btn;
+					end
+
+				// Other special keys sent to the ULA as key combinations
+				8'h66 : begin // Backspace (CAPS 0)
+						keys[0][0] <= release_btn;
+						keys[4][0] <= release_btn;
+					end
+				8'h58 : begin // Caps lock (CAPS 2)
+						keys[0][0] <= release_btn;
+						keys[3][1] <= release_btn;
+					end
 				8'h76 : begin // Escape (CAPS SPACE)
-						keys[0][0] <= 0; // CAPS SHIFT on
-						keys[7][1] <= 1; // SYMBOL SHIFT off
+						keys[0][0] <= release_btn;
+						keys[7][0] <= release_btn;
 					end
-
-				// keys that add SYMBOL SHIFT and remove CAPS SHIFT
-				// , < . > / ? ; : ' " [ { ] } - _ = + ` ~ *
-				8'h49, 8'h41, 8'h4A, 8'h4C, 8'h52, 8'h54, 8'h5b, 8'h4E, 8'h55, 8'h0E, 8'h7C, 8'h5D : begin 
-						keys[7][1] <= 0; // SYMBOL SHIFT on
-						keys[0][0] <= 1; // CAPS SHIFT off
+				8'h49 : begin // . <
+						keys[7][1] <= release_btn;
+						keys[2][4] <= release_btn | ~shift;
+						keys[7][2] <= release_btn |  shift;
 					end
-
-				default: begin
-						keys[0][0] <= ~shift; // CAPS SHIFT
-						keys[7][1] <= ~ctrl;  // SYMBOL SHIFT
+				8'h41 : begin // , >
+						keys[7][1] <= release_btn;
+						keys[2][3] <= release_btn | ~shift;
+						keys[7][3] <= release_btn |  shift;
 					end
-			endcase
-		end else begin // (release_btn) - key up
-			case(code)
-				// only sets CAPS SHIFT and SYMBOL SHIFT on shift or ctrl release
-				// fixes fast alternating between left cursor and right cursor giving 5s and 8s
-				8'h12: begin // left shift
-						keys[0][0] <= ~mod[0]; // CAPS SHIFT
+				8'h4A : begin // / ?
+						keys[7][1] <= release_btn;
+						keys[0][3] <= release_btn | ~shift;
+						keys[0][4] <= release_btn |  shift;
 					end
-				8'h59: begin // right shift
-						keys[0][0] <= ~left_shift; // CAPS SHIFT
+				8'h4C : begin // ; :
+						keys[7][1] <= release_btn;
+						keys[0][1] <= release_btn | ~shift;
+						keys[5][1] <= release_btn |  shift;
 					end
-				8'h14: begin
-						if (~extended) begin // left ctrl
-							keys[7][1] <= ~right_ctrl; // SYMBOL SHIFT
-						end else begin // right ctrl
-							keys[7][1] <= ~mod[2]; // SYMBOL SHIFT
-						end
+				8'h52 : begin // " '
+						keys[7][1] <= release_btn;
+						keys[4][3] <= release_btn | ~shift;
+						keys[5][0] <= release_btn |  shift;
+					end
+				8'h54 : begin // (
+						keys[7][1] <= release_btn;
+						keys[4][2] <= release_btn;
+					end
+				8'h5B : begin // )
+						keys[7][1] <= release_btn;
+						keys[4][1] <= release_btn;
+					end
+				8'h4E : begin // - _
+						keys[7][1] <= release_btn;
+						keys[4][0] <= release_btn | ~shift;
+						keys[6][3] <= release_btn |  shift;
+					end
+				8'h55 : begin // = +
+						keys[7][1] <= release_btn;
+						keys[6][2] <= release_btn | ~shift;
+						keys[6][1] <= release_btn |  shift;
+					end
+				8'h0E : begin // '
+						keys[7][1] <= release_btn;
+						keys[4][3] <= release_btn;
+					end
+				8'h5D : begin // *
+						keys[7][1] <= release_btn;
+						keys[7][4] <= release_btn;
 					end
 				default: ;
 			endcase
+		end else begin // recreated keyboard
+			if(!release_btn) begin // only consider key code down edges; there is a different key code for each button down and each button up
+				if(!lshift) begin
+					case(code)
+						8'h3e : keys[0][0] <= 0; // CAPS SHIFT
+						8'h46 : keys[0][0] <= 1;
+						8'h4e : keys[0][2] <= 0; // X
+						8'h55 : keys[0][2] <= 1;
+						8'h54 : keys[0][3] <= 0; // C
+						8'h5b : keys[0][3] <= 1;
+						8'h4c : keys[0][4] <= 0; // V
+
+						8'h3c : keys[2][0] <= 0; // Q
+						8'h2a : keys[2][0] <= 1;
+						8'h1d : keys[2][1] <= 0; // W
+						8'h22 : keys[2][1] <= 1;
+						8'h35 : keys[2][2] <= 0; // E
+						8'h1a : keys[2][2] <= 1;
+
+						8'h1C : keys[3][0] <= 0; // 1
+						8'h32 : keys[3][0] <= 1;
+						8'h21 : keys[3][1] <= 0; // 2
+						8'h23 : keys[3][1] <= 1;
+						8'h24 : keys[3][2] <= 0; // 3
+						8'h2b : keys[3][2] <= 1;
+						8'h34 : keys[3][3] <= 0; // 4
+						8'h33 : keys[3][3] <= 1;
+						8'h43 : keys[3][4] <= 0; // 5
+						8'h3b : keys[3][4] <= 1;
+
+						8'h1b : keys[4][0] <= 0; // 0
+						8'h2c : keys[4][0] <= 1;
+						8'h15 : keys[4][1] <= 0; // 9
+						8'h2d : keys[4][1] <= 1;
+						8'h44 : keys[4][2] <= 0; // 8
+						8'h4d : keys[4][2] <= 1;
+						8'h3a : keys[4][3] <= 0; // 7
+						8'h31 : keys[4][3] <= 1;
+						8'h42 : keys[4][4] <= 0; // 6
+						8'h4b : keys[4][4] <= 1;
+
+						8'h36 : keys[6][0] <= 0; // ENTER
+						8'h3d : keys[6][0] <= 1;
+						8'h25 : keys[6][1] <= 0; // L
+						8'h2e : keys[6][1] <= 1;
+						8'h1e : keys[6][2] <= 0; // K
+						8'h26 : keys[6][2] <= 1;
+						8'h45 : keys[6][3] <= 0; // J
+						8'h16 : keys[6][3] <= 1;
+
+						8'h4a : keys[7][3] <= 0; // N
+						8'h41 : keys[7][4] <= 0; // B
+						8'h49 : keys[7][4] <= 1;
+
+						default: ;
+					endcase
+				end else begin // left shift
+					case(code)
+						8'h41 : keys[0][1] <= 0; // Z
+						8'h49 : keys[0][1] <= 1;
+						8'h4c : keys[0][4] <= 1; // V
+
+						8'h44 : keys[1][0] <= 0; // A
+						8'h4d : keys[1][0] <= 1;
+						8'h15 : keys[1][1] <= 0; // S
+						8'h2d : keys[1][1] <= 1;
+						8'h1b : keys[1][2] <= 0; // D
+						8'h2c : keys[1][2] <= 1;
+						8'h3c : keys[1][3] <= 0; // F
+						8'h2a : keys[1][3] <= 1;
+						8'h1d : keys[1][4] <= 0; // G
+						8'h22 : keys[1][4] <= 1;
+
+						8'h1c : keys[2][3] <= 0; // R
+						8'h32 : keys[2][3] <= 1;
+						8'h21 : keys[2][4] <= 0; // T
+						8'h23 : keys[2][4] <= 1;
+
+						8'h3a : keys[5][0] <= 0; // P
+						8'h31 : keys[5][0] <= 1;
+						8'h42 : keys[5][1] <= 0; // O
+						8'h4b : keys[5][1] <= 1;
+						8'h43 : keys[5][2] <= 0; // I
+						8'h3b : keys[5][2] <= 1;
+						8'h34 : keys[5][3] <= 0; // U
+						8'h33 : keys[5][3] <= 1;
+						8'h24 : keys[5][4] <= 0; // Y
+						8'h2b : keys[5][4] <= 1;
+
+						8'h35 : keys[6][4] <= 0; // H
+						8'h1a : keys[6][4] <= 1;
+
+						8'h2e : keys[7][0] <= 0; // SPACE
+						8'h36 : keys[7][0] <= 1;
+						8'h16 : keys[7][1] <= 0; // SYMBOL SHIFT
+						8'h25 : keys[7][1] <= 1;
+						8'h54 : keys[7][2] <= 0; // M
+						8'h5b : keys[7][2] <= 1;
+						8'h4a : keys[7][3] <= 1; // N
+
+						default: ;
+					endcase
+				end
+			end
 		end
-
-		case(code)
-			// keys[0][0] CAPS SHIFT is set above
-			8'h1a : keys[0][1] <= release_btn; // Z
-			8'h22 : keys[0][2] <= release_btn; // X
-			8'h21 : keys[0][3] <= release_btn; // C
-			8'h2a : keys[0][4] <= release_btn; // V
-
-			8'h1c : keys[1][0] <= release_btn; // A
-			8'h1b : keys[1][1] <= release_btn; // S
-			8'h23 : keys[1][2] <= release_btn; // D
-			8'h2b : keys[1][3] <= release_btn; // F
-			8'h34 : keys[1][4] <= release_btn; // G
-
-			8'h15 : keys[2][0] <= release_btn; // Q
-			8'h1d : keys[2][1] <= release_btn; // W
-			8'h24 : keys[2][2] <= release_btn; // E
-			8'h2d : keys[2][3] <= release_btn; // R
-			8'h2c : keys[2][4] <= release_btn; // T
-
-			8'h16 : keys[3][0] <= release_btn; // 1
-			8'h1e : keys[3][1] <= release_btn; // 2
-			8'h26 : keys[3][2] <= release_btn; // 3
-			8'h25 : keys[3][3] <= release_btn; // 4
-			8'h2e : keys[3][4] <= release_btn; // 5
-
-			8'h45 : keys[4][0] <= release_btn; // 0
-			8'h46 : keys[4][1] <= release_btn; // 9
-			8'h3e : keys[4][2] <= release_btn; // 8
-			8'h3d : keys[4][3] <= release_btn; // 7
-			8'h36 : keys[4][4] <= release_btn; // 6
-
-			8'h4d : keys[5][0] <= release_btn; // P
-			8'h44 : keys[5][1] <= release_btn; // O
-			8'h43 : keys[5][2] <= release_btn; // I
-			8'h3c : keys[5][3] <= release_btn; // U
-			8'h35 : keys[5][4] <= release_btn; // Y
-
-			8'h5a : keys[6][0] <= release_btn; // ENTER
-			8'h4b : keys[6][1] <= release_btn; // L
-			8'h42 : keys[6][2] <= release_btn; // K
-			8'h3b : keys[6][3] <= release_btn; // J
-			8'h33 : keys[6][4] <= release_btn; // H
-
-			8'h29 : keys[7][0] <= release_btn; // SPACE
-			// keys[7][1] SYMBOL SHIFT is set above
-			8'h3a : keys[7][2] <= release_btn; // M
-			8'h31 : keys[7][3] <= release_btn; // N
-			8'h32 : keys[7][4] <= release_btn; // B
-
-			// Cursor keys - these are actually extended (E0 xx), but
-			// the scancodes for the numeric keypad cursor keys are
-			// are the same but without the extension, so we'll accept
-			// the codes whether they are extended or not
-			8'h6B : keys[3][4] <= release_btn; // Left (CAPS 5)
-			8'h72 : keys[4][4] <= release_btn; // Down (CAPS 6)
-			8'h75 : keys[4][3] <= release_btn; // Up (CAPS 7)
-			8'h74 : keys[4][2] <= release_btn; // Right (CAPS 8)
-
-			// Other special keys sent to the ULA as key combinations
-			8'h66 : keys[4][0] <= release_btn; // Backspace (CAPS 0)
-			8'h58 : keys[3][1] <= release_btn; // Caps lock (CAPS 2)
-			8'h76 : keys[7][0] <= release_btn; // Escape (CAPS SPACE)
-
-			8'h49 : begin // , <
-					keys[2][4] <= release_btn | ~shift; // <
-					keys[7][3] <= release_btn |  shift; // ,
-				end
-			8'h41 : begin // . >
-					keys[2][3] <= release_btn | ~shift; // >
-					keys[7][2] <= release_btn |  shift; // .
-				end
-			8'h4A : begin // / ?
-					keys[0][3] <= release_btn | ~shift; // ?
-					keys[0][4] <= release_btn |  shift; // /
-				end
-			8'h4C : begin // ; :
-					keys[0][1] <= release_btn | ~shift; // :
-					keys[5][1] <= release_btn |  shift; // ;
-				end
-			8'h52 : begin // ' "	
-					keys[5][0] <= release_btn | ~shift; // "
-					keys[4][3] <= release_btn |  shift; // '
-				end
-			8'h54 : keys[4][3] <= release_btn; // [ { give (
-			8'h5B : keys[4][3] <= release_btn; // ] } give )
-			8'h4E : begin // - _
-					keys[4][0] <= release_btn | ~shift; // _
-					keys[6][3] <= release_btn |  shift; // -
-				end
-			8'h55 : begin // = +
-					keys[6][2] <= release_btn | ~shift; // +
-					keys[6][1] <= release_btn |  shift; // =
-				end
-			8'h0E : keys[4][3] <= release_btn; // ` ~ give `
-			8'h7C : keys[7][4] <= release_btn; // numeric *
-			8'h5D : keys[7][4] <= release_btn; // \ | give *
-			default: ;
-		endcase
 	end
 end
 
@@ -307,7 +399,6 @@ always @(posedge clk_sys) begin
 			if(old_state != ps2_key[10]) begin
 				release_btn <= ~ps2_key[9];
 				code <= ps2_key[7:0];
-				extended <= ps2_key[8];
 				input_strobe <= 1;
 				if((ps2_key[8:0] == 9) && ~ps2_key[9]) auto_pos <= 1; // F10
 			end

--- a/rtl/keyboard.sv
+++ b/rtl/keyboard.sv
@@ -54,6 +54,7 @@ module keyboard
 reg  [4:0] keys[7:0];
 reg        release_btn = 0;
 reg  [7:0] code;
+reg        extended = 0;
 
 // Output addressed row to ULA
 assign key_data = (!addr[8]  ? keys[0] : 5'b11111)
@@ -66,7 +67,11 @@ assign key_data = (!addr[8]  ? keys[0] : 5'b11111)
                  &(!addr[15] ? keys[7] : 5'b11111);
 
 reg  input_strobe = 0;
-wire shift = mod[0];
+
+reg  left_shift = 0;
+wire shift = mod[0] | left_shift;
+reg  right_ctrl = 0;
+wire ctrl = mod[2] | right_ctrl;
 
 always @(posedge clk_sys) begin
 	reg old_reset = 0;
@@ -81,13 +86,22 @@ always @(posedge clk_sys) begin
 		keys[5] <= 5'b11111;
 		keys[6] <= 5'b11111;
 		keys[7] <= 5'b11111;
+		left_shift <= 0;
+		right_ctrl <= 0;
 	end
 
 	if(input_strobe) begin
 		case(code)
 			8'h59: mod[0]<= ~release_btn; // right shift
+			8'h12: left_shift <= ~release_btn;
 			8'h11: mod[1]<= ~release_btn; // alt
-			8'h14: mod[2]<= ~release_btn; // ctrl
+			8'h14: begin
+					if (~extended) begin
+						mod[2]<= ~release_btn; // left_ctrl
+					end else begin
+						right_ctrl <= ~release_btn;
+					end
+				end
 			8'h05: Fn[1] <= ~release_btn; // F1
 			8'h06: Fn[2] <= ~release_btn; // F2
 			8'h04: Fn[3] <= ~release_btn; // F3
@@ -100,10 +114,59 @@ always @(posedge clk_sys) begin
 			8'h09: Fn[10]<= ~release_btn; // F10
 			8'h78: Fn[11]<= ~release_btn; // F11
 		endcase
+		
+		// update CAPS SHIFT and SYMBOL SHIFT
+		if (~release_btn) begin // key down
+			case(code)
+				// special keys sent to the ULA as key combinations
+
+				// keys that add CAPS SHIFT, and remove SYMBOL SHIFT
+				8'h6B, // Left (CAPS 5)
+				8'h72, // Down (CAPS 6)
+				8'h75, // Up (CAPS 7)
+				8'h74, // Right (CAPS 8)
+				8'h66, // Backspace (CAPS 0)
+				8'h58, // Caps lock (CAPS 2)
+				8'h76 : begin // Escape (CAPS SPACE)
+						keys[0][0] <= 0; // CAPS SHIFT on
+						keys[7][1] <= 1; // SYMBOL SHIFT off
+					end
+
+				// keys that add SYMBOL SHIFT and remove CAPS SHIFT
+				// , < . > / ? ; : ' " [ { ] } - _ = + ` ~ *
+				8'h49, 8'h41, 8'h4A, 8'h4C, 8'h52, 8'h54, 8'h5b, 8'h4E, 8'h55, 8'h0E, 8'h7C, 8'h5D : begin 
+						keys[7][1] <= 0; // SYMBOL SHIFT on
+						keys[0][0] <= 1; // CAPS SHIFT off
+					end
+
+				default: begin
+						keys[0][0] <= ~shift; // CAPS SHIFT
+						keys[7][1] <= ~ctrl;  // SYMBOL SHIFT
+					end
+			endcase
+		end else begin // (release_btn) - key up
+			case(code)
+				// only sets CAPS SHIFT and SYMBOL SHIFT on shift or ctrl release
+				// fixes fast alternating between left cursor and right cursor giving 5s and 8s
+				8'h12: begin // left shift
+						keys[0][0] <= ~mod[0]; // CAPS SHIFT
+					end
+				8'h59: begin // right shift
+						keys[0][0] <= ~left_shift; // CAPS SHIFT
+					end
+				8'h14: begin
+						if (~extended) begin // left ctrl
+							keys[7][1] <= ~right_ctrl; // SYMBOL SHIFT
+						end else begin // right ctrl
+							keys[7][1] <= ~mod[2]; // SYMBOL SHIFT
+						end
+					end
+				default: ;
+			endcase
+		end
 
 		case(code)
-			8'h12 : keys[0][0] <= release_btn; // Left shift (CAPS SHIFT)
-			8'h59 : keys[0][0] <= release_btn; // Right shift (CAPS SHIFT)
+			// keys[0][0] CAPS SHIFT is set above
 			8'h1a : keys[0][1] <= release_btn; // Z
 			8'h22 : keys[0][2] <= release_btn; // X
 			8'h21 : keys[0][3] <= release_btn; // C
@@ -146,7 +209,7 @@ always @(posedge clk_sys) begin
 			8'h33 : keys[6][4] <= release_btn; // H
 
 			8'h29 : keys[7][0] <= release_btn; // SPACE
-			8'h14 : keys[7][1] <= release_btn; // CTRL (Symbol Shift)
+			// keys[7][1] SYMBOL SHIFT is set above
 			8'h3a : keys[7][2] <= release_btn; // M
 			8'h31 : keys[7][3] <= release_btn; // N
 			8'h32 : keys[7][4] <= release_btn; // B
@@ -155,87 +218,49 @@ always @(posedge clk_sys) begin
 			// the scancodes for the numeric keypad cursor keys are
 			// are the same but without the extension, so we'll accept
 			// the codes whether they are extended or not
-			8'h6B : begin // Left (CAPS 5)
-					keys[0][0] <= release_btn;
-					keys[3][4] <= release_btn;
-				end
-			8'h72 : begin // Down (CAPS 6)
-					keys[0][0] <= release_btn;
-					keys[4][4] <= release_btn;
-				end
-			8'h75 : begin // Up (CAPS 7)
-					keys[0][0] <= release_btn;
-					keys[4][3] <= release_btn;
-				end
-			8'h74 : begin // Right (CAPS 8)
-					keys[0][0] <= release_btn;
-					keys[4][2] <= release_btn;
-				end
+			8'h6B : keys[3][4] <= release_btn; // Left (CAPS 5)
+			8'h72 : keys[4][4] <= release_btn; // Down (CAPS 6)
+			8'h75 : keys[4][3] <= release_btn; // Up (CAPS 7)
+			8'h74 : keys[4][2] <= release_btn; // Right (CAPS 8)
 
 			// Other special keys sent to the ULA as key combinations
-			8'h66 : begin // Backspace (CAPS 0)
-					keys[0][0] <= release_btn;
-					keys[4][0] <= release_btn;
+			8'h66 : keys[4][0] <= release_btn; // Backspace (CAPS 0)
+			8'h58 : keys[3][1] <= release_btn; // Caps lock (CAPS 2)
+			8'h76 : keys[7][0] <= release_btn; // Escape (CAPS SPACE)
+
+			8'h49 : begin // , <
+					keys[2][4] <= release_btn | ~shift; // <
+					keys[7][3] <= release_btn |  shift; // ,
 				end
-			8'h58 : begin // Caps lock (CAPS 2)
-					keys[0][0] <= release_btn;
-					keys[3][1] <= release_btn;
-				end
-			8'h76 : begin // Escape (CAPS SPACE)
-					keys[0][0] <= release_btn;
-					keys[7][0] <= release_btn;
-				end
-			8'h49 : begin // . <
-					keys[7][1] <= release_btn;
-					keys[2][4] <= release_btn | ~shift;
-					keys[7][2] <= release_btn |  shift;
-				end
-			8'h41 : begin // , >
-					keys[7][1] <= release_btn;
-					keys[2][3] <= release_btn | ~shift;
-					keys[7][3] <= release_btn |  shift;
+			8'h41 : begin // . >
+					keys[2][3] <= release_btn | ~shift; // >
+					keys[7][2] <= release_btn |  shift; // .
 				end
 			8'h4A : begin // / ?
-					keys[7][1] <= release_btn;
-					keys[0][3] <= release_btn | ~shift;
-					keys[0][4] <= release_btn |  shift;
+					keys[0][3] <= release_btn | ~shift; // ?
+					keys[0][4] <= release_btn |  shift; // /
 				end
 			8'h4C : begin // ; :
-					keys[7][1] <= release_btn;
-					keys[0][1] <= release_btn | ~shift;
-					keys[5][1] <= release_btn |  shift;
+					keys[0][1] <= release_btn | ~shift; // :
+					keys[5][1] <= release_btn |  shift; // ;
 				end
-			8'h52 : begin // " '
-					keys[7][1] <= release_btn;
-					keys[4][3] <= release_btn | ~shift;
-					keys[5][0] <= release_btn |  shift;
+			8'h52 : begin // ' "	
+					keys[5][0] <= release_btn | ~shift; // "
+					keys[4][3] <= release_btn |  shift; // '
 				end
-			8'h54 : begin // (
-					keys[7][1] <= release_btn;
-					keys[4][2] <= release_btn;
-				end
-			8'h5B : begin // )
-					keys[7][1] <= release_btn;
-					keys[4][1] <= release_btn;
-				end
+			8'h54 : keys[4][3] <= release_btn; // [ { give (
+			8'h5B : keys[4][3] <= release_btn; // ] } give )
 			8'h4E : begin // - _
-					keys[7][1] <= release_btn;
-					keys[4][0] <= release_btn | ~shift;
-					keys[6][3] <= release_btn |  shift;
+					keys[4][0] <= release_btn | ~shift; // _
+					keys[6][3] <= release_btn |  shift; // -
 				end
 			8'h55 : begin // = +
-					keys[7][1] <= release_btn;
-					keys[6][2] <= release_btn | ~shift;
-					keys[6][1] <= release_btn |  shift;
+					keys[6][2] <= release_btn | ~shift; // +
+					keys[6][1] <= release_btn |  shift; // =
 				end
-			8'h0E : begin // '
-					keys[7][1] <= release_btn;
-					keys[4][3] <= release_btn;
-				end
-			8'h5D : begin // *
-					keys[7][1] <= release_btn;
-					keys[7][4] <= release_btn;
-				end
+			8'h0E : keys[4][3] <= release_btn; // ` ~ give `
+			8'h7C : keys[7][4] <= release_btn; // numeric *
+			8'h5D : keys[7][4] <= release_btn; // \ | give *
 			default: ;
 		endcase
 	end
@@ -282,6 +307,7 @@ always @(posedge clk_sys) begin
 			if(old_state != ps2_key[10]) begin
 				release_btn <= ~ps2_key[9];
 				code <= ps2_key[7:0];
+				extended <= ps2_key[8];
 				input_strobe <= 1;
 				if((ps2_key[8:0] == 9) && ~ps2_key[9]) auto_pos <= 1; // F10
 			end


### PR DESCRIPTION
Fixes keys such as "<," which does not give "<" when shift is pressed - this vastly improves recreated spectrum keyboard in Qwerty mode by enabling " to be typed.
Fixes rapid cursor left/right giving 5s and 8s.
Fixes switching shift keys losing caps. eg. left shift down, a down, right shift down, left shift up, a down - giving "Aa".