### PR TITLE
Add SNA 128K snapshot support with automatic 48K/128K detection

### DIFF
--- a/rtl/snap_loader.sv
+++ b/rtl/snap_loader.sv
@@ -199,9 +199,25 @@ reg   [2:0] snap_border;
 reg   [7:0] snap_1ffd;
 reg   [7:0] snap_7ffd;
 
+// SNA 128K state machine states
+localparam SNA128_IDLE    = 3'd0;
+localparam SNA128_PENDING = 3'd1; // Detect 48K vs 128K
+localparam SNA128_EXT     = 3'd2; // Parse 4-byte extended header
+localparam SNA128_REPLAY  = 3'd3; // Replay BRAM buffer to page N
+localparam SNA128_PAGES   = 3'd4; // Load remaining RAM pages
+
+reg [2:0]  sna128_state = SNA128_IDLE;
+reg [1:0]  sna128_ext_cnt;
+reg [2:0]  sna128_page_n;         // Page N from 7FFD[2:0]
+reg [13:0] sna128_replay_addr;    // BRAM replay read/write counter
+reg [13:0] sna128_page_addr;      // Offset within current remaining page
+reg [2:0]  sna128_cur_page;       // Current remaining page being loaded
+
+wire sna128_bypass = (sna128_state == SNA128_REPLAY) || (sna128_state == SNA128_PAGES);
+
 always_comb begin
 	addr = addr_pre;
-	if(hdrv1 || snap_sna) begin
+	if(!sna128_bypass && (hdrv1 || snap_sna)) begin
 		case(addr_pre[17:14])
 				0: addr[16:14] = 5;
 				1: addr[16:14] = 2;
@@ -210,6 +226,33 @@ always_comb begin
 		endcase
 	end
 end
+
+// Combinational: next remaining page (skip 2, 5, and N)
+reg [3:0] sna128_next_page;
+always_comb begin
+	sna128_next_page = {1'b0, sna128_cur_page} + 1'd1;
+	if(sna128_next_page < 4'd8 && (sna128_next_page == 4'd2 || sna128_next_page == 4'd5 || sna128_next_page[2:0] == sna128_page_n))
+		sna128_next_page = sna128_next_page + 1'd1;
+	if(sna128_next_page < 4'd8 && (sna128_next_page == 4'd2 || sna128_next_page == 4'd5 || sna128_next_page[2:0] == sna128_page_n))
+		sna128_next_page = sna128_next_page + 1'd1;
+end
+
+// 16KB dual-port BRAM buffer for third bank (destination page unknown until ext header)
+wire [7:0] bram_rd_data;
+wire [13:0] bram_rd_addr = sna128_replay_addr;
+
+dpram #(.DATAWIDTH(8), .ADDRWIDTH(14)) sna128_buf
+(
+	.clock(clk_sys),
+	.address_a(addr_pre[13:0]),
+	.data_a(snap_data),
+	.wren_a(snap_wr & snap_sna & snap_reset & (addr_pre[17:14] == 2'b10)),
+	.q_a(),
+	.address_b(bram_rd_addr),
+	.data_b(8'd0),
+	.wren_b(1'b0),
+	.q_b(bram_rd_data)
+);
 
 reg        hdrv1;
 reg  [7:0] snap_hdrlen;
@@ -238,10 +281,12 @@ always_ff @(posedge clk_sys) begin
 		snap_hdrlen <= snap_sna ? 8'd27 : 8'd30;
 		snap_reset <= 1;
 		snap_hw <= 0;
+		sna128_state <= SNA128_IDLE;
 	end
 
 	//finish download
 	if(old_download && ~ioctl_download) begin
+		sna128_state <= SNA128_IDLE;
 		if(snap_hw) begin
 			snap_REGSet <= 1;
 			snap_hwset <= 1;
@@ -262,7 +307,80 @@ always_ff @(posedge clk_sys) begin
 		else snap_REGSet <= 0;
 	end
 
-	if(ioctl_download & ioctl_wr) begin
+	// SNA 128K state machine
+	if(sna128_state != SNA128_IDLE) begin
+		case(sna128_state)
+			SNA128_PENDING: begin
+				// sz reached 0 for SNA: if more data arrives → 128K, else 48K
+				if(ioctl_wr) begin
+					// 128K confirmed: first byte is PC low
+					snap_REG[71:64] <= ioctl_data;
+					sna128_ext_cnt <= 1;
+					sna128_state <= SNA128_EXT;
+				end
+				// If download ends → 48K (handled by download-end logic)
+			end
+
+			SNA128_EXT: begin
+				if(ioctl_wr) begin
+					case(sna128_ext_cnt)
+						1: snap_REG[79:72] <= ioctl_data; // PC high
+						2: begin
+							snap_7ffd <= ioctl_data;
+							sna128_page_n <= ioctl_data[2:0];
+							snap_hw <= ARCH_ZX128;
+						end
+						3: begin
+							// TR-DOS flag (4th ext byte, ignored for now)
+							sna128_state <= SNA128_REPLAY;
+							sna128_replay_addr <= 0;
+							snap_wait <= 1; // Pause stream during BRAM replay
+						end
+					endcase
+					sna128_ext_cnt <= sna128_ext_cnt + 1'd1;
+				end
+			end
+
+			SNA128_REPLAY: begin
+				// Replay buffered third bank from BRAM to correct SDRAM page N
+				// BRAM read output is unregistered (combinational)
+				addr_pre <= {4'b0000, sna128_page_n, sna128_replay_addr};
+				snap_data <= bram_rd_data;
+				snap_wr <= 1;
+
+				if(sna128_replay_addr == 14'h3FFF) begin
+					sna128_state <= SNA128_PAGES;
+					sna128_cur_page <= (sna128_page_n == 3'd0) ? 3'd1 : 3'd0;
+					sna128_page_addr <= 0;
+					snap_wait <= 0; // Resume stream for remaining pages
+				end else begin
+					sna128_replay_addr <= sna128_replay_addr + 1'd1;
+				end
+			end
+
+			SNA128_PAGES: begin
+				// Load remaining RAM pages from byte stream
+				if(ioctl_wr) begin
+					addr_pre <= {4'b0000, sna128_cur_page, sna128_page_addr};
+					snap_data <= ioctl_data;
+					snap_wr <= 1;
+
+					if(sna128_page_addr == 14'h3FFF) begin
+						sna128_page_addr <= 0;
+						if(sna128_next_page < 4'd8) begin
+							sna128_cur_page <= sna128_next_page[2:0];
+						end else begin
+							sna128_state <= SNA128_IDLE;
+							finish <= 1;
+						end
+					end else begin
+						sna128_page_addr <= sna128_page_addr + 1'd1;
+					end
+				end
+			end
+		endcase
+	end
+	else if(ioctl_download & ioctl_wr) begin
 		if (ioctl_addr<snap_hdrlen) begin
 			if (!snap_sna) case(ioctl_addr[6:0]) // Z80
 				 0: snap_REG[7:0]     <= ioctl_data; //a
@@ -443,14 +561,16 @@ always_ff @(posedge clk_sys) begin
 			if(comp_state>=3) begin
 				sz <= sz - 1'd1;
 				if(sz == 1) begin
-					if(snap_hdrlen == 30 || snap_sna) finish <= 1;
+					if(snap_hdrlen == 30) finish <= 1;
+					else if(snap_sna) sna128_state <= SNA128_PENDING;
 					else comp_state <= 0;
 				end
 			end
 		end
 	end
 
-	if(~snap_wr & snap_wait & ram_ready) begin
+	// RLE expansion drain (only when not in 128K state machine to avoid clearing snap_wait)
+	if(~snap_wr & snap_wait & ram_ready & (sna128_state == SNA128_IDLE)) begin
 		if(cnt) begin
 			addr_pre <= addr;
 			addr <= addr + 1'd1;


### PR DESCRIPTION
- Add 5-state FSM (IDLE/PENDING/EXT/REPLAY/PAGES) for streaming 128K SNA
- Use 16KB BRAM buffer for third bank (destination page unknown until ext header)
- Auto-detect 48K vs 128K by stream continuation past 49179 bytes
- Parse extended header: PC, port 7FFD, TR-DOS flag
- Replay BRAM to correct SDRAM page N after extended header reveals 7FFD[2:0]
- Load remaining pages in ascending order, skipping pages 2, 5, and N
- 48K path unchanged, Z80 snapshot path unchanged
- No HPS/ARM code changes required