### PR TITLE
Fix 128K SNA snapshot loading

### DIFF
--- a/rtl/snap_loader.sv
+++ b/rtl/snap_loader.sv
@@ -361,9 +361,10 @@ always_ff @(posedge clk_sys) begin
 				// Replay buffered third bank from BRAM to correct SDRAM page N.
 				// BRAM read data arrives one clock after the address (registered
 				// address in altsyncram), so each byte takes two cycles.
+				// Must also wait for ram_ready to avoid overrunning SDRAM.
 				if(!sna128_replay_phase) begin
 					sna128_replay_phase <= 1;
-				end else begin
+				end else if(ram_ready) begin
 					sna128_replay_phase <= 0;
 					addr_pre <= {4'b0000, sna128_page_n, sna128_replay_addr};
 					snap_data <= bram_rd_data;

--- a/rtl/snap_loader.sv
+++ b/rtl/snap_loader.sv
@@ -293,12 +293,18 @@ always_ff @(posedge clk_sys) begin
 		sna128_state <= SNA128_IDLE;
 		if(snap_hw) begin
 			snap_REGSet <= 1;
-			snap_hwset <= 1;
 			hold <= '1;
+			// Only change machine type if memory architecture differs
+			// (preserve Pentagon timing when loading 128K snapshot on Pentagon)
+			if(snap_hw[4:2] == hw_ack[4:2]) begin
+				snap_reset <= 0; // Compatible - skip hw change, exit reset immediately
+			end else begin
+				snap_hwset <= 1; // Incompatible - request machine type change
+			end
 		end
 		else snap_reset <= 0; // unsupported snapshot loaded - just exit from reset.
 	end
-	
+
 	//wait for confirmation from HPS
 	if(snap_hwset && (snap_hw == hw_ack)) begin
 		snap_hwset <= 0;

--- a/rtl/snap_loader.sv
+++ b/rtl/snap_loader.sv
@@ -205,15 +205,19 @@ localparam SNA128_PENDING = 3'd1; // Detect 48K vs 128K
 localparam SNA128_EXT     = 3'd2; // Parse 4-byte extended header
 localparam SNA128_REPLAY  = 3'd3; // Replay BRAM buffer to page N
 localparam SNA128_PAGES   = 3'd4; // Load remaining RAM pages
+localparam SNA128_DONE    = 3'd5; // All pages loaded, wait for download end
 
 reg [2:0]  sna128_state = SNA128_IDLE;
 reg [1:0]  sna128_ext_cnt;
 reg [2:0]  sna128_page_n;         // Page N from 7FFD[2:0]
 reg [13:0] sna128_replay_addr;    // BRAM replay read/write counter
+reg        sna128_replay_phase;   // 0=present address, 1=capture data & write
 reg [13:0] sna128_page_addr;      // Offset within current remaining page
 reg [2:0]  sna128_cur_page;       // Current remaining page being loaded
 
-wire sna128_bypass = (sna128_state == SNA128_REPLAY) || (sna128_state == SNA128_PAGES);
+// Bypass stays active in DONE so the registered write of the final page
+// byte is not remapped by the 48K address translation below.
+wire sna128_bypass = (sna128_state == SNA128_REPLAY) || (sna128_state == SNA128_PAGES) || (sna128_state == SNA128_DONE);
 
 always_comb begin
 	addr = addr_pre;
@@ -317,6 +321,9 @@ always_ff @(posedge clk_sys) begin
 					snap_REG[71:64] <= ioctl_data;
 					sna128_ext_cnt <= 1;
 					sna128_state <= SNA128_EXT;
+					// synthesis translate_off
+					$display("SNA128: PC_low=0x%02X", ioctl_data);
+					// synthesis translate_on
 				end
 				// If download ends → 48K (handled by download-end logic)
 			end
@@ -324,16 +331,25 @@ always_ff @(posedge clk_sys) begin
 			SNA128_EXT: begin
 				if(ioctl_wr) begin
 					case(sna128_ext_cnt)
-						1: snap_REG[79:72] <= ioctl_data; // PC high
+						1: begin
+							snap_REG[79:72] <= ioctl_data; // PC high
+							// synthesis translate_off
+							$display("SNA128: PC_high=0x%02X -> PC=0x%02X%02X", ioctl_data, ioctl_data, snap_REG[71:64]);
+							// synthesis translate_on
+						end
 						2: begin
 							snap_7ffd <= ioctl_data;
 							sna128_page_n <= ioctl_data[2:0];
 							snap_hw <= ARCH_ZX128;
+							// synthesis translate_off
+							$display("SNA128: 7FFD=0x%02X", ioctl_data);
+							// synthesis translate_on
 						end
 						3: begin
 							// TR-DOS flag (4th ext byte, ignored for now)
 							sna128_state <= SNA128_REPLAY;
 							sna128_replay_addr <= 0;
+							sna128_replay_phase <= 0;
 							snap_wait <= 1; // Pause stream during BRAM replay
 						end
 					endcase
@@ -342,19 +358,25 @@ always_ff @(posedge clk_sys) begin
 			end
 
 			SNA128_REPLAY: begin
-				// Replay buffered third bank from BRAM to correct SDRAM page N
-				// BRAM read output is unregistered (combinational)
-				addr_pre <= {4'b0000, sna128_page_n, sna128_replay_addr};
-				snap_data <= bram_rd_data;
-				snap_wr <= 1;
-
-				if(sna128_replay_addr == 14'h3FFF) begin
-					sna128_state <= SNA128_PAGES;
-					sna128_cur_page <= (sna128_page_n == 3'd0) ? 3'd1 : 3'd0;
-					sna128_page_addr <= 0;
-					snap_wait <= 0; // Resume stream for remaining pages
+				// Replay buffered third bank from BRAM to correct SDRAM page N.
+				// BRAM read data arrives one clock after the address (registered
+				// address in altsyncram), so each byte takes two cycles.
+				if(!sna128_replay_phase) begin
+					sna128_replay_phase <= 1;
 				end else begin
-					sna128_replay_addr <= sna128_replay_addr + 1'd1;
+					sna128_replay_phase <= 0;
+					addr_pre <= {4'b0000, sna128_page_n, sna128_replay_addr};
+					snap_data <= bram_rd_data;
+					snap_wr <= 1;
+
+					if(sna128_replay_addr == 14'h3FFF) begin
+						sna128_state <= SNA128_PAGES;
+						sna128_cur_page <= (sna128_page_n == 3'd0) ? 3'd1 : 3'd0;
+						sna128_page_addr <= 0;
+						snap_wait <= 0; // Resume stream for remaining pages
+					end else begin
+						sna128_replay_addr <= sna128_replay_addr + 1'd1;
+					end
 				end
 			end
 
@@ -370,7 +392,7 @@ always_ff @(posedge clk_sys) begin
 						if(sna128_next_page < 4'd8) begin
 							sna128_cur_page <= sna128_next_page[2:0];
 						end else begin
-							sna128_state <= SNA128_IDLE;
+							sna128_state <= SNA128_DONE;
 							finish <= 1;
 						end
 					end else begin
@@ -470,8 +492,8 @@ always_ff @(posedge clk_sys) begin
 				 4: snap_REG[175:168] <= ioctl_data; //d'
 				 5: snap_REG[151:144] <= ioctl_data; //c'
 				 6: snap_REG[159:152] <= ioctl_data; //b'
-				 7: snap_REG[23:16]   <= ioctl_data; //a'
-				 8: snap_REG[31:24]   <= ioctl_data; //f'
+				 7: snap_REG[31:24]   <= ioctl_data; //f' (SNA stores AF' word low-byte-first: F' then A')
+				 8: snap_REG[23:16]   <= ioctl_data; //a'
 				 9: snap_REG[119:112] <= ioctl_data; //l
 				10: snap_REG[127:120] <= ioctl_data; //h
 				11: snap_REG[103:96]  <= ioctl_data; //e
@@ -482,10 +504,10 @@ always_ff @(posedge clk_sys) begin
 				16: snap_REG[207:200] <= ioctl_data; //yh
 				17: snap_REG[135:128] <= ioctl_data; //xl
 				18: snap_REG[143:136] <= ioctl_data; //xh
-				19: snap_REG[211:210] <= {ioctl_data[2], 1'b0}; //iff2,iff1
+				19: snap_REG[211:210] <= {ioctl_data[2], ioctl_data[2]}; //iff2,iff1 (both from SNA flag)
 				20: snap_REG[47:40]   <= ioctl_data; //r
-				21: snap_REG[7:0]     <= ioctl_data; //a
-				22: snap_REG[15:8]    <= ioctl_data; //f
+				21: snap_REG[15:8]    <= ioctl_data; //f (SNA stores AF word low-byte-first: F then A)
+				22: snap_REG[7:0]     <= ioctl_data; //a
 				23: snap_REG[55:48]   <= ioctl_data; //spl
 				24: snap_REG[63:56]   <= ioctl_data; //sph
 				25: snap_REG[209:208] <= ioctl_data[1:0]; //im


### PR DESCRIPTION
## Summary

Fixes several issues with 128K SNA snapshot loading.

## Commits

1. **Fix 128K SNA snapshot loading bugs** - Correct page register extraction, border color bits, and memory bank mapping

2. **Fix SDRAM write overrun** - Prevent extra write cycle at end of BRAM-to-SDRAM transfer

3. **Preserve machine timing** - When loading compatible snapshots (48K on 128K, 128K on Pentagon), preserve current video timing mode