### PR TITLE
Fix AY envelope default shape for bass synthesis

### DIFF
--- a/rtl/ym2149.sv
+++ b/rtl/ym2149.sv
@@ -77,6 +77,7 @@ always @(posedge CLK) begin
 	if(RESET) begin
 		ymreg     <= '{default:0};
 		ymreg[7]  <= '1;
+		ymreg[13] <= 8'h08; // Default envelope shape: continuous sawtooth (\\\\)
 		addr      <= '0;
 		env_reset <= 0;
 	end else begin


### PR DESCRIPTION
## Summary

Set envelope register 13 default to 0x08 (continuous sawtooth) instead of 0x00.

## Problem

Games like Eyeache by ESI use envelope shapes for bass tones and expect a reasonable default rather than the hardware's undefined state. Without this fix, bass is missing in music that relies on envelope-based synthesis without explicitly initializing the envelope shape register.

## Change

`rtl/ym2149.sv`: Set `ymreg[13] <= 8'h08` on reset.