### PR TITLE
Fix ULA snow effect timing for ZX-48

### DIFF
--- a/rtl/ula.sv
+++ b/rtl/ula.sv
@@ -197,9 +197,14 @@ always @(posedge clk_sys) begin
 				'hA,'hE: vaddr[14:7] <= {stdpage ? page_scr : tmx_cfg[0],1'b1,vc[7:6],vc[2:0],vc[5]}; // CAS and page(?) only
 			endcase
 
-			// Snow effect for ULA-48 only. ULA-128 has no snow bug.
-			if (mZX & ~m128 & ~nMREQ & ~nRFSH & contendAddr & snow_ena) case(hc_next[3:0])
-				'h8,'hC: vaddr[6:0] <= addr[6:0]; // only RAS got replaced
+			// Snow effect: ZX-48 ULA ignores RFSH, causing display corruption when
+			// I register is 0x40-0x7F. During Z80 refresh cycle, IR appears on address
+			// bus. ULA mistakes this for video RAM access and latches wrong row address.
+			// Reference: http://www.zxdesign.info/harlequinSnow.shtml
+			// Only affects ULA-48; ULA-128/Pentagon check RFSH and avoid the bug.
+			// Use latched MREQ/RFSH (sampled on CPUClk low) for correct timing alignment.
+			if (mZX & ~m128 & ~mreqt23 & ~rfsht23 & contendAddr & snow_ena) case(hc_next[3:0])
+				'h8,'hC: vaddr[6:0] <= addr[6:0]; // R register corrupts DRAM row address
 			endcase
 
 			case(hc_next[3:0])
@@ -245,6 +250,7 @@ assign     ulap_color = palette[(tmx_hi ? hiSRegister[15] : SRegister[7]) ? {Att
 reg  CPUClk;
 reg  ioreqtw3;
 reg  mreqt23;
+reg  rfsht23;
 
 wire ioreq_n      = (addr[0] & ~(ulap_acc & ulap_avail)) | nIORQ;
 wire clkwait_next = hc_next[2] | hc_next[3];
@@ -264,9 +270,10 @@ always @(posedge clk_sys) begin
 	if(ce_7mp) next_clk_r <= next_clk;
 
 	if(~CPUClk) begin
-		// These are transparent latches!
+		// Transparent latches - sample CPU signals during CPUClk low phase
 		ioreqtw3 <= ioreq_n;
 		mreqt23  <= nMREQ;
+		rfsht23  <= nRFSH;  // For snow effect timing
 	end
 end
 


### PR DESCRIPTION
## Summary

- Fix ULA snow effect timing to match real ZX-48 hardware behavior
- Use latched MREQ/RFSH signals for correct timing alignment with video fetch
- Snow now appears on correct scanlines when I register is 0x40-0x7F

## Technical Details

The ZX-48 ULA has a bug where it ignores the RFSH signal during memory access. When the Z80 I register is set to 0x40-0x7F, refresh cycles cause IR to appear on the address bus, which the ULA mistakes for a video RAM access. This corrupts the DRAM row address, creating the characteristic "snow" effect.

The previous implementation used raw nMREQ/nRFSH signals which caused incorrect timing. The fix samples these signals through transparent latches (during CPUClk low phase), matching how the real ULA hardware operates.

Reference: http://www.zxdesign.info/harlequinSnow.shtml

## Test Plan

- [x] Tested with snow48c0.tap test program
- [x] Snow appears on correct scanlines (top 3 lines of each character row when synchronized)
- [x] No snow on ZX-128 mode (correct - ULA-128 has no snow bug)