### PR TITLE
TZX: implement robust F2/F3 block navigation

### DIFF
--- a/rtl/tape.sv
+++ b/rtl/tape.sv
@@ -71,6 +71,9 @@ tzxplayer #(.TZX_MS(CLOCK/1000)) tzxplayer
 	.stop(tzx_stop),
 	.stop48k(tzx_stop48k),
 	.restart_tape(~tape_ready || tape_mode != 2'b10),
+	.restart_block(tzx_restart_block),
+	.skip_block(tzx_skip_block),
+	.new_block(tzx_new_block),
 	.host_tap_in(din_r),
 	.cass_read(tzx_audio),
 	.cass_motor(!play_pause && tape_mode == 2'b10)
@@ -93,11 +96,14 @@ wire        tzx_loop_start;
 wire        tzx_loop_next;
 wire        tzx_stop;
 wire        tzx_stop48k;
+wire        tzx_new_block;
+reg         tzx_restart_block;
+reg         tzx_skip_block;
 
 always @(posedge clk_sys) begin
 	reg old_pause, old_prev, old_next, old_ready, old_rden;
 
-	reg [24:0] blk_list[32];
+	reg [24:0] blk_list[128];
 	reg [15:0] blocksz;
 	reg  [5:0] hdrsz;
 	reg [15:0] pilot;
@@ -112,7 +118,8 @@ always @(posedge clk_sys) begin
 	reg        skip;
 	reg        turboskip;
 	reg        auto_blk;
-	reg  [4:0] blk_num;
+	reg  [6:0] blk_num;
+	reg        blk_pending;
 	reg        old_stdload;
 	reg        old_read_done;
 	reg [24:0] tzx_loop_addr;
@@ -147,15 +154,19 @@ always @(posedge clk_sys) begin
 			hdrsz <= 32;
 			read_done <= 0;
 		end
+		if(tape_mode == 2'b10 && tape_size > 25'd10) begin
+			blk_list[1] <= tape_size - 25'd10;
+		end
 	end
 
 	// supply TZX data
 	old_read_done <= read_done;
+	tzx_restart_block <= 0;
 	if (tape_ready && tape_mode == 2'b10) begin
 		audio_out <= tzx_audio;
-		if(tzx_stop | (mode48k & tzx_stop48k)) play_pause <= 1;
-		if(tzx_loop_start) tzx_loop_addr <= addr;
-		if(tzx_loop_next) begin
+		if((tzx_stop | (mode48k & tzx_stop48k)) & ~tzx_restart_block) play_pause <= 1;
+		if(tzx_loop_start & ~tzx_restart_block) tzx_loop_addr <= addr;
+		if(tzx_loop_next & ~tzx_restart_block) begin
 			addr <= tzx_loop_addr;
 			read_cnt <= read_cnt + (addr - tzx_loop_addr);
 		end
@@ -165,6 +176,45 @@ always @(posedge clk_sys) begin
 			addr <= addr + 1'b1;
 		end else if (read_cnt && read_done && (tzx_req ^ tzx_ack)) begin
 			read_done <= 0;
+		end
+
+		if(tzx_new_block & ~tzx_restart_block) begin
+			blk_pending <= 0;
+			if(blk_num != 7'd127) begin
+				blk_num <= blk_num + 1'b1;
+				blk_list[blk_num + 1'b1] <= read_cnt + 1'b1;
+			end
+		end
+
+		old_prev <= prev;
+		if(prev & ~old_prev) begin
+			play_pause <= 0;
+			if(blk_pending & (blk_num >= 1)) begin
+				addr     <= size - blk_list[blk_num];
+				read_cnt <= blk_list[blk_num];
+				blk_num  <= blk_num - 1'b1;
+			end else if(~blk_pending & (blk_num >= 2)) begin
+				addr     <= size - blk_list[blk_num - 1'b1];
+				read_cnt <= blk_list[blk_num - 1'b1];
+				blk_num  <= blk_num - 2'd2;
+			end else begin
+				addr     <= size - blk_list[1];
+				read_cnt <= blk_list[1];
+				blk_num  <= 0;
+			end
+			blk_pending <= 1;
+			tzx_restart_block <= 1;
+			tzx_skip_block    <= 0;  // cancel any pending F3 skip on direction change
+			rd_req    <= 0;
+			read_done <= 0;
+		end
+
+		if(tzx_new_block) tzx_skip_block <= 0;
+
+		old_next <= next;
+		if(next & ~old_next) begin
+			play_pause     <= 0;
+			tzx_skip_block <= 1;
 		end
 	end
 
@@ -183,8 +233,10 @@ always @(posedge clk_sys) begin
 		auto_blk <= 0;
 		blk_list <= '{default:0};
 		blk_num  <= 0;
+		blk_pending <= 0;
 		rd_req   <= 0;
 		audio_out<= 1;
+		tzx_skip_block <= 0;
 	end else if(ce) begin
 
 		old_stdload <= stdload;

--- a/rtl/tzxplayer.vhd
+++ b/rtl/tzxplayer.vhd
@@ -34,6 +34,9 @@ port(
 	clk             : in std_logic;
 	ce              : in std_logic;
 	restart_tape    : in std_logic;
+	restart_block   : in std_logic;                     -- pulse: jump to TZX_NEWBLOCK without re-reading the 10-byte header
+	skip_block      : in std_logic;                     -- level: fast-forward to the next navigation boundary
+	new_block       : out std_logic;                    -- one-cycle pulse when a navigable block/group starts
 
 	host_tap_in     : in std_logic_vector(7 downto 0);  -- 8bits fifo input
 	tzx_req         : buffer std_logic;                 -- request for new byte (edge trigger)
@@ -87,7 +90,8 @@ type tzx_state_t is (
 	TZX_PLAY_TAPBLOCK4,
 	TZX_DIRECT,
 	TZX_DIRECT2,
-	TZX_DIRECT3);
+	TZX_DIRECT3,
+	TZX_SKIP);
 
 signal tzx_state: tzx_state_t;
 
@@ -108,6 +112,7 @@ signal cass_motor_D   : std_logic;
 signal motor_counter  : std_logic_vector(21 downto 0);
 signal loop_iter      : std_logic_vector(15 downto 0);
 signal data_len_dword : std_logic_vector(31 downto 0);
+signal group_active   : std_logic;
 
 begin
 
@@ -127,6 +132,8 @@ begin
 		loop_start <= '0';
 		loop_next <= '0';
 		loop_iter <= (others => '0');
+		group_active <= '0';
+		new_block <= '0';
 
 	else
 
@@ -171,8 +178,9 @@ begin
 		loop_next  <= '0';
 		stop       <= '0';
 		stop48k    <= '0';
+		new_block  <= '0';
 
-		if playing = '1' and pulse_len = 0 and tzx_req = tzx_ack then
+		if playing = '1' and pulse_len = 0 and tzx_req = tzx_ack and restart_block = '0' then
 
 			tzx_req <= not tzx_ack; -- default request for new data
 
@@ -187,6 +195,13 @@ begin
 			when TZX_NEWBLOCK =>
 				tzx_offset <= (others=>'0');
 				ms_counter <= (others=>'0');
+				if group_active = '0' and (
+					tap_fifo_do = x"10" or tap_fifo_do = x"11" or
+					tap_fifo_do = x"12" or tap_fifo_do = x"13" or
+					tap_fifo_do = x"14" or tap_fifo_do = x"15"
+				) then
+					new_block <= '1';
+				end if;
 				case tap_fifo_do is
 					when x"10" => tzx_state <= TZX_NORMAL;
 					when x"11" => tzx_state <= TZX_TURBO;
@@ -197,8 +212,11 @@ begin
 					when x"18" => null; -- CSW recording (not implemented)
 					when x"19" => null; -- Generalized data block (not implemented)
 					when x"20" => tzx_state <= TZX_PAUSE;
-					when x"21" => tzx_state <= TZX_TEXT; -- Group start
-					when x"22" => null; -- Group end
+					when x"21" => -- Group start: index the composite block itself.
+						tzx_state <= TZX_TEXT;
+						if group_active = '0' then new_block <= '1'; end if;
+						group_active <= '1';
+					when x"22" => group_active <= '0'; -- Group end
 					when x"23" => null; -- Jump to block (not implemented)
 					when x"24" => tzx_state <= TZX_LOOP_START;
 					when x"25" => tzx_state <= TZX_LOOP_END;
@@ -215,6 +233,9 @@ begin
 					when x"5A" => tzx_state <= TZX_GLUE;
 					when others => null;
 				end case;
+				if loop_iter > 1 then
+					new_block <= '0';
+				end if;
 
 			when TZX_LOOP_START =>
 				tzx_offset <= tzx_offset + 1;
@@ -516,10 +537,78 @@ begin
 					tzx_state <= TZX_DIRECT2;
 				end if;
 
+			when TZX_SKIP =>
+				if data_len = 0 then
+					tzx_state <= TZX_NEWBLOCK;
+					tzx_req   <= tzx_ack;
+				else
+					data_len <= data_len - 1;
+				end if;
+
 			when others => null;
 			end case;
 
+			if skip_block = '1' and (
+				tzx_state = TZX_PLAY_TAPBLOCK2 or tzx_state = TZX_PLAY_TAPBLOCK4 or
+				tzx_state = TZX_DIRECT2
+			) then
+				pulse_len  <= (others => '0');
+				pause_len  <= (others => '0');
+				ms_counter <= (others => '0');
+				data_len   <= data_len - 1;
+				tzx_state  <= TZX_SKIP;
+				tzx_req    <= not tzx_ack;
+			elsif skip_block = '1' and (
+				tzx_state = TZX_PLAY_TONE   or tzx_state = TZX_PLAY_SYNC1 or
+				tzx_state = TZX_PLAY_SYNC2  or tzx_state = TZX_PLAY_TAPBLOCK or
+				tzx_state = TZX_PLAY_TAPBLOCK3 or tzx_state = TZX_DIRECT3
+			) then
+				pulse_len  <= (others => '0');
+				pause_len  <= (others => '0');
+				ms_counter <= (others => '0');
+				tzx_state  <= TZX_SKIP;
+				tzx_req    <= not tzx_ack;
+			elsif skip_block = '1' and tzx_state = TZX_PAUSE2 then
+				pulse_len  <= (others => '0');
+				pause_len  <= (others => '0');
+				ms_counter <= (others => '0');
+				tzx_state  <= TZX_NEWBLOCK;
+				tzx_req    <= tzx_ack;
+			elsif skip_block = '1' and tzx_state = TZX_TONE and tzx_offset >= x"03" then
+				pulse_len  <= (others => '0');
+				pause_len  <= (others => '0');
+				ms_counter <= (others => '0');
+				data_len   <= (others => '0');
+				tzx_state  <= TZX_SKIP;
+				tzx_req    <= not tzx_ack;
+			elsif skip_block = '1' and tzx_state = TZX_PULSES then
+				pulse_len  <= (others => '0');
+				pause_len  <= (others => '0');
+				ms_counter <= (others => '0');
+				if    tzx_offset = x"00" then
+					data_len <= "000000000000000" & tap_fifo_do & '0';
+				elsif tzx_offset = x"01" then
+					data_len <= ("000000000000000" & data_len(7 downto 0) & '0') - 1;
+				else
+					data_len <= ("000000000000000" & data_len(7 downto 0) & '0') - 2;
+				end if;
+				tzx_state  <= TZX_SKIP;
+				tzx_req    <= not tzx_ack;
+			end if;
+
 		end if; -- play tzx
+
+		-- F2 (prev) request: jump straight to TZX_NEWBLOCK without re-reading the 10-byte header
+		if restart_block = '1' then
+			tzx_offset <= (others => '0');
+			tzx_state  <= TZX_NEWBLOCK;
+			pulse_len  <= (others => '0');
+			pause_len  <= (others => '0');
+			ms_counter <= (others => '0');
+			loop_iter  <= (others => '0');
+			group_active <= '0';
+			tzx_req    <= not tzx_ack; -- request the block-ID byte at the new addr
+		end if;
 
 	end if;
   end if; -- clk


### PR DESCRIPTION
## Summary

- add history-backed F2/F3 navigation for playable TZX blocks
- make rewind restart the player cleanly, flush in-flight SDRAM reads, and handle rapid repeated F2 presses and boundary races
- make forward navigation skip standard, turbo, pure-data, direct-recording, tone, pulse-sequence, and pause states with correct byte accounting
- avoid duplicate history entries across TZX loop iterations and safely cap the navigation history
- treat `0x21`/`0x22` groups as atomic composite blocks, preventing protected loaders such as SpeedLock from landing inside tone, sync, or data fragments

## Implementation Details.
- **Navigation History Cap**: Saturates the boundary tracker at 128 to ensure >128-block files (like multi-level games) don't wrap and clobber the first-block fallback pointers. F2 simply rewinds to the most recent tracked block beyond 128.
- **F2 Boundary Races & SDRAM Flush**: Freezes the FSM during the 1-cycle F2 restart window. A byte acknowledged right before rewind belongs to the abandoned stream, so it suppresses dispatching to prevent corrupting history. It also holds `rd_req` low for one clock to ensure the SDRAM fetch skips its capture branch, forcing a fresh read from the rewound address.
- **Precise F3 Skip Alignment**: Recomputes `data_len` across various mid-byte, pre-data, or post-byte states (including pulse sequences that consume 2 bytes per pulse). This ensures the skip loop always lands exactly on the next block's ID byte. Off-by-one skips would parse parameters as block IDs, shifting the entire stream and causing parity errors in loaded blocks.
- **TZX Loops**: Suppresses boundary markers on non-final iterations of `0x24`/`0x25` loops so duplicate history entries aren't recorded on every pass.
- **Group Blocking**: Blocks between 0x21 and 0x22 are treated as one boundary. Exposing every internal subblock (pure-tone, data fragment) would allow users to restart in the middle of a waveform where protected loaders cannot synchronize.

## Validation

- checked the combined commit for whitespace errors
- parsed `Battle Command (1991)(Ocean)(128K)(Side A)[SpeedLock 7].tzx` and verified that its 40 playable signal fragments produce four valid navigation targets: normal header, normal loader, SpeedLock block 1, and SpeedLock block 2
- verified the intended F2 mapping, including the rapid-repeat pending path

Quartus compilation and hardware testing done.
